### PR TITLE
Add Translation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 AlphabeticalAppGrid@stuarthayhurst.shell-extension.zip
+/locale
+*~

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 ![Extension](docs/icon.png)
 ## Create an extension bundle:
-  - `gnome-extensions pack ../alphabetical-grid-extension`
+  - `./scripts/create-release.sh`
 
 ## Install the extension bundle:
-  - `gnome-extensions install AlphabeticalAppGrid@stuarthayhurst.shell-extension.zip`
+  - `./scripts/create-release.sh -i`
   - Reload GNOME
   - Enable the extension
 

--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,11 @@ const {GLib} = imports.gi;
 const Main = imports.ui.main;
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
+const Gettext = imports.gettext;
+Gettext.textdomain("AlphabeticalAppGrid@stuarthayhurst");
+Gettext.bindtextdomain("AlphabeticalAppGrid@stuarthayhurst", ExtensionSystem.extensionMeta["AlphabeticalAppGrid@stuarthayhurst"].path + "/locale");
+
+const _ = Gettext.gettext;
 
 function enable() {
   gridReorder = new Extension();
@@ -43,22 +48,22 @@ class Extension {
 
       //Trigger a refresh of the app grid, if shell version is greater than 40
       if (this.shellVersion < 40) {
-        this._logMessage('Running GNOME shell 3.38 or lower, skipping reload');
+        this._logMessage(_('Running GNOME shell 3.38 or lower, skipping reload'));
       } else {
         //Use call() so 'this' applies to this._appDisplay
         this.reloadAppDisplay.call(this._appDisplay);
       }
 
-      this._logMessage('Reordered grid');
+      this._logMessage(_('Reordered grid'));
     } else {
-      this._logMessage('org.gnome.shell app-picker-layout in unwritable, skipping reorder');
+      this._logMessage(_('org.gnome.shell app-picker-layout in unwritable, skipping reorder'));
     }
   }
 
   waitForFolderChange() {
     //If a folder was made or deleted, trigger a reorder
     this.folderSignal = this.folderSettings.connect('changed::folder-children', () => {
-      this._logMessage('Folders changed, triggering reorder');
+      this._logMessage(_('Folders changed, triggering reorder'));
       this.reorderGrid();
     });
   }
@@ -70,7 +75,7 @@ class Extension {
       let appLayout = this.shellSettings.get_value('app-picker-layout');
       if (appLayout.recursiveUnpack() != '') {
         //When an external change is picked up, reorder the grid
-        this._logMessage('App grid layout changed, triggering reorder');
+        this._logMessage(_('App grid layout changed, triggering reorder'));
         this.reorderGrid();
       }
     });

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,7 @@
   "name": "Alphabetical App Grid",
   "description": "Restore the alphabetical ordering of the app grid",
   "uuid": "AlphabeticalAppGrid@stuarthayhurst",
+  "gettext-domain": "AlphabeticalAppGrid@stuarthayhurst",
   "url": "https://github.com/stuarthayhurst/alphabetical-grid-extension",
   "shell-version": [
     "3.38",

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,41 @@
+# German translation for the Alphabetical App Grid GNOME Shell Extension.
+# Copyright (C) 2021 Stuart Hayhurst
+# This file is distributed under the same license as the alphabetical-grid-extension package.
+# Philipp Kiemle <philipp.kiemle@gmail.com>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: alphabetical-grid-extension\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-25 13:25+0200\n"
+"PO-Revision-Date: 2021-05-25 13:55+0200\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
+"Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.4.2\n"
+
+#: extension.js:51
+msgid "Running GNOME shell 3.38 or lower, skipping reload"
+msgstr "Es läuft GNOME Shell 3.38 oder niedriger, neu laden wird übersprungen"
+
+#: extension.js:57
+msgid "Reordered grid"
+msgstr "Raster wurde neu geordnet"
+
+#: extension.js:59
+msgid "org.gnome.shell app-picker-layout in unwritable, skipping reorder"
+msgstr ""
+"org.gnome.shell app-picker-layout ist nicht schreibbar, Neuordnung wird "
+"übersprungen"
+
+#: extension.js:66
+msgid "Folders changed, triggering reorder"
+msgstr "Ordner geändert, Neuordnung wird ausgelöst"
+
+#: extension.js:78
+msgid "App grid layout changed, triggering reorder"
+msgstr "Layout des Anwendungsrasters geändert, Neuordung wird ausgelöst"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1,0 +1,38 @@
+# <LANGUAGE> translation for the Alphabetical App Grid GNOME Shell Extension.
+# Copyright (C) 2021 Stuart Hayhurst
+# This file is distributed under the same license as the alphabetical-grid-extension package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: alphabetical-grid-extension\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-25 13:56+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: extension.js:51
+msgid "Running GNOME shell 3.38 or lower, skipping reload"
+msgstr ""
+
+#: extension.js:57
+msgid "Reordered grid"
+msgstr ""
+
+#: extension.js:59
+msgid "org.gnome.shell app-picker-layout in unwritable, skipping reorder"
+msgstr ""
+
+#: extension.js:66
+msgid "Folders changed, triggering reorder"
+msgstr ""
+
+#: extension.js:78
+msgid "App grid layout changed, triggering reorder"
+msgstr ""

--- a/scripts/compile-locales.sh
+++ b/scripts/compile-locales.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script is derived from the awesome Fly-Pie Project (https://github.com/Schneegans/Fly-Pie),
+# originally licensed under the MIT license (https://github.com/Schneegans/Fly-Pie/blob/develop/LICENSE).
+# Modifications were made in order to make the script work with this repository.
+
+# This script creates a compiled *.mo translation file for each *.po file in the 'po'
+# directory. This script doesn't need to be executed manually, it gets called by create-release.sh.
+
+# Exit the script when one command fails.
+set -e
+
+# Check if all necessary commands are available.
+if ! command -v msgfmt &> /dev/null
+then
+  echo "ERROR: Could not find msgfmt. On Ubuntu based systems, check if the gettext package is installed!"
+  exit 1
+fi
+
+# Go to the repo root.
+cd "$( cd "$( dirname "$0" )" && pwd )/.." || \
+  { echo "ERROR: Could not find the repo root."; exit 1; }
+
+for FILE in po/*.po
+do
+  # Handle the case of no .po files, see SC2045
+  [[ -e "$FILE" ]] || { echo "ERROR: No .po files found, exiting."; exit 1; }
+  # Extract the language code from the filename.
+  LANGUAGE="${FILE##*/}"
+  LANGUAGE="${LANGUAGE%.*}"
+
+  # Compile the corresponding *.mo file.
+  echo "Creating localization for '$LANGUAGE'..."
+  mkdir -p locale/"$LANGUAGE"/LC_MESSAGES
+  msgfmt --check --verbose "$FILE" -o locale/"$LANGUAGE"/LC_MESSAGES/messages.mo
+done
+
+echo "All locales compiled!"

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# This script is derived from the awesome Fly-Pie Project (https://github.com/Schneegans/Fly-Pie),
+# originally licensed under the MIT license (https://github.com/Schneegans/Fly-Pie/blob/develop/LICENSE).
+# Modifications were made in order to make the script work with this repository.
+
+# This script creates a new release of the Alphabetical App Grid GNOME extension.
+# When the '-i' option is set, it directly installs it to the system.
+# When the '-s' option is set, the script throws an error (instead of just a warning) when the
+#   zip file is too big. This is recommended when uploading it to the GNOME Extensions website.
+#   We think that the limit is 4096 KB, but we found no official documentation on this so far.
+
+# Exit the script when one command fails.
+set -e
+
+# Print usage info
+usage() {
+    echo "Use '-i' to install the extension to your system. To just build it, run the script without any flag."
+    echo "Use '-s' to throw an error when the zip size is too big to be uploaded to the Extensions website."
+}
+
+
+# Go to the repo root.
+cd "$( cd "$( dirname "$0" )" && pwd )/.." || \
+  { echo "ERROR: Could not find the repo root."; exit 1; }
+
+scripts/compile-locales.sh
+
+# Delete any old zip and pack everything together
+# shellcheck disable=2015
+gnome-extensions pack --force --extra-source=LICENSE.txt . && \
+    echo "Extension packed successfully!" || \
+    { echo "ERROR: Could not pack the extension."; exit 1; }
+
+
+while getopts is FLAG; do
+	case $FLAG in
+		
+		i)  # Install the extension, but only if this would not overwrite the git repository.
+            if ! [[ $(pwd) == *".local/share/gnome-shell/extensions/AlphabeticalAppGrid@stuarthayhurst" ]]; then
+                # shellcheck disable=2015
+                gnome-extensions install AlphabeticalAppGrid@stuarthayhurst.shell-extension.zip --force && \
+                echo "Extension installed successfully! Now restart the Shell ('Alt'+'F2', then 'r')." || \
+                { echo "ERROR: Could not install the extension."; exit 1; }
+            else
+                echo "Skipping install step, the repo is already located in the extensions directory."
+                echo "Restart the Shell to get the updated version ('Alt'+'F2', then 'r')."
+            fi;;
+
+        s)  # We need to throw an error because of the zip size
+            SIZE_ERROR="true";;
+
+		*)	echo "ERROR: Invalid flag!"
+            usage
+            exit 1;;
+	esac
+done
+
+# Check zip file size
+SIZE=$(stat -c %s AlphabeticalAppGrid@stuarthayhurst.shell-extension.zip)
+
+# If the zip is too big and a check is requested, throw an error. Otherwise just print a warning.
+if [[ "$SIZE" -gt 4096000 ]]; then
+    if [ "$SIZE_ERROR" = "true" ]; then
+        echo "ERROR! The zip is too big to be uploaded to the Extensions website. Keep it smaller than 4096 KB!"
+        exit 2
+    else
+        echo "WARNING! The zip is too big to be uploaded to the Extensions website. Keep it smaller than 4096 KB!"
+    fi
+fi

--- a/scripts/update-po.sh
+++ b/scripts/update-po.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# This script is derived from the awesome Fly-Pie Project (https://github.com/Schneegans/Fly-Pie),
+# originally licensed under the MIT license (https://github.com/Schneegans/Fly-Pie/blob/develop/LICENSE).
+# Modifications were made in order to make the script work with this repository.
+
+# This script takes 'po/messages.pot' and compiles the latest '.po' file(s) from it.
+# Usage: update-po.sh -l <LANG-CODE>, where <LANG-CODE> is the language code of the file
+# you want to update. Pass '-a' to update all '.po' files.
+
+# Print usage info
+usage() {
+  echo "Use '-l <LANG-CODE>' to update a specific '.po' file."
+  echo "Use '-a' to update all '.po' files."
+}
+
+# Create a new translation from 'messages.pot'. Do not update the template because
+# of potential merge conflicts. This is done in a seperate step.
+promptNewTranslation() {
+  echo -n "The translation for '$1' does not exist. Do you want to create it? [Y/n] "
+  read -r reply
+
+  # Default to 'Yes' when no answer given
+  if [ -z "$reply" ] || [ "$reply" = "Y" ] ||  [ "$reply" = "y" ]; then
+    msginit --input=po/messages.pot --locale="$1" --output-file="po/$1.po"
+    # Add Copyright info
+    sed -i "2s/.*/# Copyright (C) $(date +%Y) Stuart Hayhurst/" po/"$1".po
+  fi
+}
+
+
+if ! command -v msgmerge &> /dev/null
+then
+  echo "ERROR: Could not find msgmerge. On Ubuntu based systems, check if the gettext package is installed!"
+  exit 1
+fi
+
+# Go to the repo root.
+cd "$( cd "$( dirname "$0" )" && pwd )/.." || \
+  { echo "ERROR: Could not find the repo root."; exit 1; }
+
+while getopts l:a FLAG; do
+  case $FLAG in
+
+    l)  # Update/Create one specific '.po' file.
+        # Check if a valid language code was passed.
+        if test -f po/"$OPTARG".po; then
+          echo -n "Updating '$OPTARG.po' "
+          msgmerge --previous -U po/"$OPTARG".po po/messages.pot
+
+          # Check the state of the translation progress.
+          # We don't want to actually create a .mo file, so we direct it to /dev/null.
+          msgfmt --check --verbose --output-file=/dev/null po/"$OPTARG".po
+          exit
+        else
+          promptNewTranslation "$OPTARG"
+          exit
+        fi;;
+
+    a)  # Update all '.po' files.
+        for FILE in po/*.po; do
+          # handle the case of no .po files, see SC2045
+          [[ -e "$FILE" ]] || { echo "ERROR: No .po files found, exiting."; exit 1; }
+          echo -n "Updating '$FILE' "
+          msgmerge --previous -U "$FILE" po/messages.pot
+
+          # Check the state of the translation progress.
+          msgfmt --check --verbose "$FILE"
+        done
+        exit;;
+
+    *)  # Handle invalid flags.
+        echo "ERROR: Invalid flag!"
+        usage
+        exit 1;;
+  esac
+done
+
+# In case no flag was specified
+echo "ERROR: You need to specify a flag!"
+usage
+exit 1

--- a/scripts/update-po.sh
+++ b/scripts/update-po.sh
@@ -65,7 +65,8 @@ while getopts l:a FLAG; do
           msgmerge --previous -U "$FILE" po/messages.pot
 
           # Check the state of the translation progress.
-          msgfmt --check --verbose "$FILE"
+          # We don't want to actually create a .mo file, so we direct it to /dev/null.
+          msgfmt --check --verbose --output-file=/dev/null po/"$OPTARG".po
         done
         exit;;
 

--- a/scripts/update-pot.sh
+++ b/scripts/update-pot.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script is derived from the awesome Fly-Pie Project (https://github.com/Schneegans/Fly-Pie),
+# originally licensed under the MIT license (https://github.com/Schneegans/Fly-Pie/blob/develop/LICENSE).
+# Modifications were made in order to make the script work with this repository.
+
+# This script scans the source code for any translatable strings and updates
+# the po/messages.pot file accordingly. To merge the new strings into a translation,
+# run update-po.sh -l <LANG-CODE>.
+
+# Exit the script when one command fails.
+set -e
+
+echo "Generating 'messages.pot'..."
+
+# Check if all necessary commands are available.
+if ! command -v xgettext &> /dev/null
+then
+  echo "ERROR: Could not find xgettext. On Ubuntu based systems, check if the gettext package is installed!"
+  exit 1
+fi
+
+# Go to the repo root.
+cd "$( cd "$( dirname "$0" )" && pwd )/.." || \
+  { echo "ERROR: Could not find the repo root."; exit 1; }
+
+# Update the template file with the strings from the source tree. All preceeding
+# comments starting with 'Translators' will be extracted as well.
+xgettext --from-code=UTF-8 \
+         --add-comments=Translators \
+         --copyright-holder="Stuart Hayhurst" \
+         --package-name="alphabetical-grid-extension" \
+         --output=po/messages.pot \
+         extension.js
+
+# Replace some lines of the header with our own.
+sed -i '1s/.*/# <LANGUAGE> translation for the Alphabetical App Grid GNOME Shell Extension./' po/messages.pot
+sed -i "2s/.*/# Copyright (C) $(date +%Y) Stuart Hayhurst/" po/messages.pot
+sed -i '17s/CHARSET/UTF-8/' po/messages.pot
+
+echo "'messages.pot' generated!"


### PR DESCRIPTION
First off - this is quite a big PR. I'll try to explain what everything does here (and the files themselves are commented as well).

These scripts are mostly the work of Simon Schneegans (the dev of [Fly-Pie](https://github.com/Schneegans/Fly-Pie)) and me.

If you want to learn more about how translating extensions works, I recommend
- https://wiki.gnome.org/Projects/GnomeShell/Extensions/FAQ/CreatingExtensions#Translate
- https://www.codeproject.com/Articles/5271677/How-to-Create-A-GNOME-Extension (section "Gettext Translation")
- and of course watching videos on YouTube.

**update-pot.sh**
This script checks the source code for any translatable strings and puts them into `po/messages.pot`. This is sort of a template file from which the actual translation files for each language get derived.
You should run this script whenever you change translatable strings in the source code in order for them to show up in the translation files.

**update-po.sh**
This script updates/creates a `po` file for a specific language. When the `-l` flag is passed, it will check for this specific language code and update or create the translation file in the `/po` directory.
If the -a flag is passed, it will update all existing `po` files.
One old `po` file will be kept as backup by `msgmerge` with a `po~` extension, but it doesn't need to be tracked by git.

**compile-locales.sh**
This script doesn't need to be executed manually,  it gets called by `create-release.sh`.
It parses all human-readable `po` files into machine-readable `mo` files. Those are stored in `/locale` and don't need to be tracked by git, because they are only created when you create a release.

**create-release.sh**
This script incorporates the translation workflow in the release process. It may clash with your usual release workflow, so feel free to edit it to your liking!
I've added an option to directly install the fresh zip file to the system (`-i`), which should make debugging and testing very easy. To achieve the same effect, some extension devs put their git repo in the place where the installed extension should be - `-i`would then overwrite the repo, but the script prevents that by checking the current working directory.
It also has a size check which is needed for big extensions, I don't think we'll get anywhere near it ;)
An option to improve this script would be to include a version number flag, in order to automatically adjust the version number in `metadata.json` and other places.

Feel free to ask if anything is unclear!
You can also commit changes directly to my branch prior to accepting this PR.