### PR TITLE
Add preferences dialogue and implement toggle for folder contents reordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 AlphabeticalAppGrid@stuarthayhurst.shell-extension.zip
 /locale
 *~
+/schemas/gschemas.compiled

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 AlphabeticalAppGrid@stuarthayhurst.shell-extension.zip
-/locale
-*~
-/schemas/gschemas.compiled
+locale/
+po/*.po~
+prefs.ui~
+schemas/gschemas.compiled

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ UUID=AlphabeticalAppGrid@stuarthayhurst
 
 build:
 	./scripts/compile-locales.sh
+	glib-compile-schemas schemas
 	gnome-extensions pack --force --extra-source=LICENSE.txt
 release:
 	$(MAKE) translations

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ install:
 uninstall:
 	gnome-extensions uninstall "$(UUID)"
 clean:
-	rm -rf locale "$(UUID).shell-extension.zip"
+	rm -rf locale schemas/gschemas.compiled "$(UUID).shell-extension.zip"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ UUID=AlphabeticalAppGrid@stuarthayhurst
 build:
 	./scripts/compile-locales.sh
 	glib-compile-schemas schemas
-	gnome-extensions pack --force --extra-source=LICENSE.txt
+	gnome-extensions pack --force --extra-source=LICENSE.txt --extra-source=prefs.ui
 release:
 	$(MAKE) translations
 	$(MAKE) build

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 ## Build dependencies: (Only required if running `make build`)
   - gnome-extensions
   - gettext
+  - libglib2.0-bin
   - sed
 
 ## Create an extension bundle:

--- a/extension.js
+++ b/extension.js
@@ -2,14 +2,13 @@ const {GLib, Gio, Shell} = imports.gi;
 const Main = imports.ui.main;
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
-const Gettext = imports.gettext;
+const Me = ExtensionUtils.getCurrentExtension();
 
 //Use _() for translations
-const Me = ExtensionUtils.getCurrentExtension();
-const _ = Gettext.domain(Me.metadata.uuid).gettext;
+const _ = imports.gettext.domain(Me.metadata.uuid).gettext;
 
 function init() {
-  ExtensionUtils.initTranslations(Me.metadata.uuid);
+  ExtensionUtils.initTranslations();
 }
 
 function enable() {

--- a/extension.js
+++ b/extension.js
@@ -36,6 +36,8 @@ class Extension {
     this.shellSettings = ExtensionUtils.getSettings('org.gnome.shell');
     //Load gsettings values for folders, to access 'folder-children'
     this.folderSettings = ExtensionUtils.getSettings('org.gnome.desktop.app-folders');
+    //Load gsettings values for the extension itself
+    this.settings = ExtensionUtils.getSettings()
     //Get access to appDisplay
     this._appDisplay = Main.overview._overview._controls._appDisplay;
     //Get GNOME shell version

--- a/extension.js
+++ b/extension.js
@@ -36,7 +36,7 @@ class Extension {
     //Load gsettings values for folders, to access 'folder-children'
     this.folderSettings = ExtensionUtils.getSettings('org.gnome.desktop.app-folders');
     //Load gsettings values for the extension itself
-    this.settings = ExtensionUtils.getSettings()
+    this._extensionSettings = ExtensionUtils.getSettings()
     //Get access to appDisplay
     this._appDisplay = Main.overview._overview._controls._appDisplay;
     //Get GNOME shell version
@@ -94,7 +94,9 @@ class Extension {
 
   reorderGrid() {
     //Alphabetically order the contents of each folder
-    this.reorderFolderContents();
+    if (this._extensionSettings.get_boolean('sort-folder-contents')) {
+      this.reorderFolderContents();
+    }
 
     //Alphabetically order the grid, by blanking the gsettings value for 'app-picker-layout'
     if (this.shellSettings.is_writable('app-picker-layout')) {

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
   "description": "Restore the alphabetical ordering of the app grid",
   "uuid": "AlphabeticalAppGrid@stuarthayhurst",
   "gettext-domain": "AlphabeticalAppGrid@stuarthayhurst",
+  "settings-schema": "org.gnome.shell.extensions.alphabetical-app-grid",
   "url": "https://github.com/stuarthayhurst/alphabetical-grid-extension",
   "shell-version": [
     "3.38",

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-30 15:54+0200\n"
+"POT-Creation-Date: 2021-05-30 20:43+0100\n"
 "PO-Revision-Date: 2021-05-30 16:00+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -22,49 +22,36 @@ msgstr ""
 msgid "Reordering folder contents"
 msgstr "Ordnerinhalt neu ordnen"
 
-#: extension.js:107
+#: extension.js:108
 msgid "Running GNOME shell 3.38 or lower, skipping reload"
 msgstr "Es läuft GNOME Shell 3.38 oder niedriger, neu laden wird übersprungen"
 
-#: extension.js:113
+#: extension.js:114
 msgid "Reordered grid"
 msgstr "Raster wurde neu geordnet"
 
-#: extension.js:115
+#: extension.js:116
 msgid "org.gnome.shell app-picker-layout is unwritable, skipping reorder"
-msgstr ""
-"org.gnome.shell app-picker-layout ist nicht schreibbar, Neuordnung wird "
-"übersprungen"
+msgstr "org.gnome.shell app-picker-layout ist nicht schreibbar, Neuordnung wird übersprungen"
 
-#: extension.js:125
+#: extension.js:126
 msgid "Folders changed, triggering reorder"
 msgstr "Ordner wurden geändert, Neuordnung wird ausgelöst"
 
-#: extension.js:143
+#: extension.js:144
 msgid "App grid layout changed, triggering reorder"
 msgstr "Layout des Anwendungsrasters wurde geändert, Neuordung wird ausgelöst"
 
-#: extension.js:159
+#: extension.js:160
 msgid "Favourite apps changed, triggering reorder"
 msgstr "Favorisierte Anwendungen wurden geändet, Neuordnung wird ausgelöst"
 
-#: prefs.ui:26
-msgctxt "setting-tooltip"
-msgid "Whether application folders should be listed in front of applications"
-msgstr "Legt fest, ob Ordner vor Anwendungen aufgelistet werden sollen"
-
-#: prefs.ui:42
-msgctxt "setting-name"
-msgid "List folders first"
-msgstr "Ordner am Anfang auflisten"
-
-#: prefs.ui:78
+#: prefs.ui:22
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
-msgstr ""
-"Legt fest, ob Ordnerinhalte ebenfalls alphabetisch geordnet werden sollen"
+msgstr "Legt fest, ob Ordnerinhalte ebenfalls alphabetisch geordnet werden sollen"
 
-#: prefs.ui:96
+#: prefs.ui:40
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Ordnerinhalt sortieren"

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-30 11:15+0100\n"
-"PO-Revision-Date: 2021-05-27 22:33+0200\n"
+"POT-Creation-Date: 2021-05-30 15:54+0200\n"
+"PO-Revision-Date: 2021-05-30 16:00+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
 "Language: de\n"
@@ -18,30 +18,53 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: extension.js:55
+#: extension.js:56
 msgid "Reordering folder contents"
-msgstr "Ordner-Inhalt neu ordnen"
+msgstr "Ordnerinhalt neu ordnen"
 
-#: extension.js:105
+#: extension.js:107
 msgid "Running GNOME shell 3.38 or lower, skipping reload"
 msgstr "Es läuft GNOME Shell 3.38 oder niedriger, neu laden wird übersprungen"
 
-#: extension.js:111
+#: extension.js:113
 msgid "Reordered grid"
 msgstr "Raster wurde neu geordnet"
 
-#: extension.js:113
+#: extension.js:115
 msgid "org.gnome.shell app-picker-layout is unwritable, skipping reorder"
-msgstr "org.gnome.shell app-picker-layout ist nicht schreibbar, Neuordnung wird übersprungen"
+msgstr ""
+"org.gnome.shell app-picker-layout ist nicht schreibbar, Neuordnung wird "
+"übersprungen"
 
-#: extension.js:123
+#: extension.js:125
 msgid "Folders changed, triggering reorder"
 msgstr "Ordner wurden geändert, Neuordnung wird ausgelöst"
 
-#: extension.js:141
+#: extension.js:143
 msgid "App grid layout changed, triggering reorder"
 msgstr "Layout des Anwendungsrasters wurde geändert, Neuordung wird ausgelöst"
 
-#: extension.js:157
+#: extension.js:159
 msgid "Favourite apps changed, triggering reorder"
+msgstr "Favorisierte Anwendungen wurden geändet, Neuordnung wird ausgelöst"
+
+#: prefs.ui:26
+msgctxt "setting-tooltip"
+msgid "Whether application folders should be listed in front of applications"
+msgstr "Legt fest, ob Ordner vor Anwendungen aufgelistet werden sollen"
+
+#: prefs.ui:42
+msgctxt "setting-name"
+msgid "List folders first"
+msgstr "Ordner am Anfang auflisten"
+
+#: prefs.ui:78
+msgctxt "setting-tooltip"
+msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
+"Legt fest, ob Ordnerinhalte ebenfalls alphabetisch geordnet werden sollen"
+
+#: prefs.ui:96
+msgctxt "setting-name"
+msgid "Sort folder contents"
+msgstr "Ordnerinhalt sortieren"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-30 11:17+0100\n"
+"POT-Creation-Date: 2021-05-30 15:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,30 +17,50 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:55
+#: extension.js:56
 msgid "Reordering folder contents"
 msgstr ""
 
-#: extension.js:105
+#: extension.js:107
 msgid "Running GNOME shell 3.38 or lower, skipping reload"
 msgstr ""
 
-#: extension.js:111
+#: extension.js:113
 msgid "Reordered grid"
 msgstr ""
 
-#: extension.js:113
+#: extension.js:115
 msgid "org.gnome.shell app-picker-layout is unwritable, skipping reorder"
 msgstr ""
 
-#: extension.js:123
+#: extension.js:125
 msgid "Folders changed, triggering reorder"
 msgstr ""
 
-#: extension.js:141
+#: extension.js:143
 msgid "App grid layout changed, triggering reorder"
 msgstr ""
 
-#: extension.js:157
+#: extension.js:159
 msgid "Favourite apps changed, triggering reorder"
+msgstr ""
+
+#: prefs.ui:26
+msgctxt "setting-tooltip"
+msgid "Whether application folders should be listed in front of applications"
+msgstr ""
+
+#: prefs.ui:42
+msgctxt "setting-name"
+msgid "List folders first"
+msgstr ""
+
+#: prefs.ui:78
+msgctxt "setting-tooltip"
+msgid "Whether the contents of folders should be sorted alphabetically"
+msgstr ""
+
+#: prefs.ui:96
+msgctxt "setting-name"
+msgid "Sort folder contents"
 msgstr ""

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-30 15:54+0200\n"
+"POT-Creation-Date: 2021-05-30 20:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,46 +21,36 @@ msgstr ""
 msgid "Reordering folder contents"
 msgstr ""
 
-#: extension.js:107
+#: extension.js:108
 msgid "Running GNOME shell 3.38 or lower, skipping reload"
 msgstr ""
 
-#: extension.js:113
+#: extension.js:114
 msgid "Reordered grid"
 msgstr ""
 
-#: extension.js:115
+#: extension.js:116
 msgid "org.gnome.shell app-picker-layout is unwritable, skipping reorder"
 msgstr ""
 
-#: extension.js:125
+#: extension.js:126
 msgid "Folders changed, triggering reorder"
 msgstr ""
 
-#: extension.js:143
+#: extension.js:144
 msgid "App grid layout changed, triggering reorder"
 msgstr ""
 
-#: extension.js:159
+#: extension.js:160
 msgid "Favourite apps changed, triggering reorder"
 msgstr ""
 
-#: prefs.ui:26
-msgctxt "setting-tooltip"
-msgid "Whether application folders should be listed in front of applications"
-msgstr ""
-
-#: prefs.ui:42
-msgctxt "setting-name"
-msgid "List folders first"
-msgstr ""
-
-#: prefs.ui:78
+#: prefs.ui:22
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
 
-#: prefs.ui:96
+#: prefs.ui:40
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr ""

--- a/prefs.js
+++ b/prefs.js
@@ -1,0 +1,28 @@
+const {GObject, Gtk} = imports.gi;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+
+
+function init () {}
+
+function buildPrefsWidget () {
+  let widget = new MyPrefsWidget();
+  widget.show_all();
+  return widget;
+}
+
+const MyPrefsWidget = GObject.registerClass(
+class MyPrefsWidget extends Gtk.ScrolledWindow {
+
+  _init (params) {
+
+    super._init(params);
+
+    let builder = new Gtk.Builder();
+    builder.set_translation_domain(Me.metadata.uuid);
+    //Load the Glade UI layout file
+    builder.add_from_file(Me.path + '/prefs.ui');
+    
+    this.add( builder.get_object('main-prefs') );
+  }
+});

--- a/prefs.js
+++ b/prefs.js
@@ -2,27 +2,45 @@ const {GObject, Gtk} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
+var PrefsWidget = class PrefsWidget {
+  constructor() {
+    this._settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.alphabetical-app-grid');
 
-function init () {}
+    this._builder = new Gtk.Builder();
+    this._builder.set_translation_domain(Me.metadata.uuid);
+    this._builder.add_from_file(Me.path + '/prefs.ui');
 
-function buildPrefsWidget () {
-  let widget = new MyPrefsWidget();
-  widget.show_all();
-  return widget;
+    this.widget = new Gtk.ScrolledWindow();
+    this.widget.add(this._builder.get_object('main-prefs'));
+
+    this._foldersSwitch = this._builder.get_object('sort-folders-switch')
+
+    //Set sliders to match the gsettings vlaues for the extension
+    this._updateSwitch(this._foldersSwitch, 'sort-folder-contents');
+
+    //Update gsettings values when switches are toggled
+    this._listenForChanges(this._foldersSwitch, 'sort-folder-contents');
+  }
+
+  _listenForChanges(targetSwitch, gsettingsKey) {
+    //Update gsettings value when switch is toggled
+    targetSwitch.connect('state-set', () => {
+      this._settings.set_boolean(gsettingsKey, targetSwitch.get_active());
+    });
+  }
+
+  //Requires the element to toggle and the gsettings key to base it off of
+  _updateSwitch(targetSwitch, gsettingsKey) {
+    targetSwitch.set_active(this._settings.get_boolean(gsettingsKey));
+  }
 }
 
-const MyPrefsWidget = GObject.registerClass(
-class MyPrefsWidget extends Gtk.ScrolledWindow {
+function init() {
+  ExtensionUtils.initTranslations();
+}
 
-  _init (params) {
-
-    super._init(params);
-
-    let builder = new Gtk.Builder();
-    builder.set_translation_domain(Me.metadata.uuid);
-    //Load the Glade UI layout file
-    builder.add_from_file(Me.path + '/prefs.ui');
-    
-    this.add( builder.get_object('main-prefs') );
-  }
-});
+function buildPrefsWidget() {
+  let settings = new PrefsWidget();
+  settings.widget.show_all();
+  return settings.widget;
+}

--- a/prefs.ui
+++ b/prefs.ui
@@ -19,58 +19,6 @@
           <object class="GtkListBoxRow">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
-            <property name="tooltip-text" translatable="yes" context="setting-tooltip">Whether application folders should be listed in front of applications</property>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-top">12</property>
-                <property name="margin-bottom">12</property>
-                <property name="orientation">vertical</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes" context="setting-name">List folders first</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSwitch" id="folders-first-switch">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="active">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkListBoxRow">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
             <property name="tooltip-text" translatable="yes" context="setting-tooltip">Whether the contents of folders should be sorted alphabetically</property>
             <child>
               <object class="GtkBox">

--- a/prefs.ui
+++ b/prefs.ui
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.18"/>
+  <object class="GtkBox" id="main-prefs">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="margin-top">10</property>
+    <property name="margin-bottom">10</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkListBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="selection-mode">none</property>
+        <child>
+          <object class="GtkListBoxRow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="tooltip-text" translatable="yes" context="setting-tooltip">Whether application folders should be listed in front of applications</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes" context="setting-name">List folders first</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="folders-first-switch">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="active">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkListBoxRow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="tooltip-text" translatable="yes" context="setting-tooltip">Whether the contents of folders should be sorted alphabetically</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">32</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="valign">center</property>
+                        <property name="label" translatable="yes" context="setting-name">Sort folder contents</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="sort-folders-switch">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="valign">center</property>
+                        <property name="active">True</property>
+                        <signal name="state-set" handler="on_my_switch_state_set" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.alphabetical-app-grid"
+    path="/org/gnome/shell/extensions/alphabetical-app-grid/">
+
+    <key name="folders-first" type="b">
+      <default>true</default>
+      <summary>List folders first</summary>
+      <description>Whether application folders should be listed in front of applications.</description>
+    </key>
+
+    <key name="sort-folder-contents" type="b">
+      <default>true</default>
+      <summary>Sort Folder contents</summary>
+      <description>Whether the contents of folders should be sorted alphabetically.</description>
+    </key>
+
+  </schema>
+</schemalist>

--- a/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema id="org.gnome.shell.extensions.alphabetical-app-grid"
-    path="/org/gnome/shell/extensions/alphabetical-app-grid/">
-
-    <key name="folders-first" type="b">
-      <default>true</default>
-      <summary>List folders first</summary>
-      <description>Whether application folders should be listed in front of applications.</description>
-    </key>
-
+  <schema id="org.gnome.shell.extensions.alphabetical-app-grid" path="/org/gnome/shell/extensions/alphabetical-app-grid/">
     <key name="sort-folder-contents" type="b">
       <default>true</default>
-      <summary>Sort Folder contents</summary>
-      <description>Whether the contents of folders should be sorted alphabetically.</description>
+      <summary>Sort folder contents</summary>
+      <description>Whether the contents of folders should be sorted alphabetically</description>
     </key>
-
   </schema>
 </schemalist>

--- a/scripts/update-pot.sh
+++ b/scripts/update-pot.sh
@@ -22,7 +22,7 @@ xgettext --from-code=UTF-8 \
          --copyright-holder="Stuart Hayhurst" \
          --package-name="alphabetical-grid-extension" \
          --output=po/messages.pot \
-         extension.js
+         *.js *.ui
 
 #Replace some lines of the header with our own.
 sed -i '1s/.*/# <LANGUAGE> translation for the Alphabetical App Grid GNOME Shell Extension./' po/messages.pot


### PR DESCRIPTION
This is a very noob approach at adding a settings dialogue.
I mostly took the code from [here](https://www.codeproject.com/Articles/5271677/How-to-Create-A-GNOME-Extension) and adapted it to this extension. There is a tutorial series on YouTube from the same guy who wrote the blog post [here](https://www.youtube.com/playlist?list=PLr3kuDAFECjZhW-p56BoVB7SubdUHBVQT). Parts 4, 6 and 7 are about this topic, maybe give them a watch if you can handle his rather slow speed of explaining things xD

As I am fairly new to developing extensions and coding in general, I am afraid that I don't know how to make the extension listen to the settings dialogue and adjusting its behaviour accordingly. I know that you can read and write settings with `gridReorder.settings.get_XXX()` and `gridReorder.settings.set_XXX()` (see blog post linked above), but that's about it xD

I hope that you still find this useful and see it as a basis to build things off of!
What do you think?
As usual, you can commit directly to my branch if necessary.