### PR TITLE
Add shellcheck as GitHub Action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,19 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Run shellcheck
+        run: |
+          find $GITHUB_WORKSPACE -type f -and \( -name "*.sh" \) | xargs shellcheck

--- a/scripts/update-pot.sh
+++ b/scripts/update-pot.sh
@@ -22,7 +22,7 @@ xgettext --from-code=UTF-8 \
          --copyright-holder="Stuart Hayhurst" \
          --package-name="alphabetical-grid-extension" \
          --output=po/messages.pot \
-         *.js *.ui
+         -- *.js *.ui
 
 #Replace some lines of the header with our own.
 sed -i '1s/.*/# <LANGUAGE> translation for the Alphabetical App Grid GNOME Shell Extension./' po/messages.pot


### PR DESCRIPTION
This checks the `*.sh` files for errors with [`shellcheck`](https://github.com/koalaman/shellcheck), which ensures code quality.

Maybe we can add a JS linter as well, to catch errors before something happens? Do you use a specific one?