### PR TITLE
Added 'About' page to settings menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ UUID=AlphabeticalAppGrid@stuarthayhurst
 
 build:
 	glib-compile-schemas schemas
-	gnome-extensions pack --force --podir=po --extra-source=LICENSE.txt --extra-source=prefs.ui
+	gnome-extensions pack --force --podir=po --extra-source=LICENSE.txt --extra-source=prefs.ui --extra-source=docs/icon.svg
 release:
 	$(MAKE) translations
 	$(MAKE) build

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-01 14:53+0100\n"
+"POT-Creation-Date: 2021-06-01 16:36+0100\n"
 "PO-Revision-Date: 2021-05-31 22:55+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -52,6 +52,22 @@ msgstr "Favorisierte Anwendungen wurden geändet, Neuordnung wird ausgelöst"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 
+#: prefs.js:33
+msgid "Alphabetical App Grid"
+msgstr ""
+
+#: prefs.js:34
+msgid "Restore the alphabetical ordering of the app grid"
+msgstr ""
+
+#: prefs.js:36
+msgid "© 2021 Stuart Hayhurst"
+msgstr ""
+
+#: prefs.js:40
+msgid "Contribute on GitHub"
+msgstr ""
+
 #: prefs.ui:27
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
@@ -63,7 +79,11 @@ msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Ordnerinhalt sortieren"
 
-#: prefs.ui:102
+#: prefs.ui:98
+msgid "About"
+msgstr ""
+
+#: prefs.ui:118
 msgid ""
 "© 2021 Stuart Hayhurst\n"
 "Licensed under <a href=\"https://www.gnu.org/licenses/gpl-3.0-standalone.html"
@@ -77,6 +97,6 @@ msgstr ""
 "Mitwirken auf <a href=\"https://github.com/stuarthayhurst/alphabetical-grid-"
 "extension\">GitHub</a>"
 
-#: prefs.ui:125
+#: prefs.ui:141
 msgid "General settings"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-01 16:36+0100\n"
+"POT-Creation-Date: 2021-06-01 18:59+0100\n"
 "PO-Revision-Date: 2021-05-31 22:55+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -79,24 +79,10 @@ msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Ordnerinhalt sortieren"
 
-#: prefs.ui:98
-msgid "About"
-msgstr ""
-
-#: prefs.ui:118
-msgid ""
-"© 2021 Stuart Hayhurst\n"
-"Licensed under <a href=\"https://www.gnu.org/licenses/gpl-3.0-standalone.html"
-"\">GPL v3.0</a>\n"
-"Contribute on <a href=\"https://github.com/stuarthayhurst/alphabetical-grid-"
-"extension\">GitHub</a>"
-msgstr ""
-"© 2021 Stuart Hayhurst\n"
-"Lizensiert unter <a href=\"https://www.gnu.org/licenses/gpl-3.0-standalone."
-"html\">GPL v3.0</a>\n"
-"Mitwirken auf <a href=\"https://github.com/stuarthayhurst/alphabetical-grid-"
-"extension\">GitHub</a>"
-
-#: prefs.ui:141
+#: prefs.ui:95
 msgid "General settings"
+msgstr ""
+
+#: prefs.ui:117
+msgid "About"
 msgstr ""

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-01 14:53+0100\n"
+"POT-Creation-Date: 2021-06-01 16:41+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,6 +49,22 @@ msgstr ""
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 
+#: prefs.js:33
+msgid "Alphabetical App Grid"
+msgstr ""
+
+#: prefs.js:34
+msgid "Restore the alphabetical ordering of the app grid"
+msgstr ""
+
+#: prefs.js:36
+msgid "© 2021 Stuart Hayhurst"
+msgstr ""
+
+#: prefs.js:40
+msgid "Contribute on GitHub"
+msgstr ""
+
 #: prefs.ui:27
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
@@ -59,7 +75,11 @@ msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr ""
 
-#: prefs.ui:102
+#: prefs.ui:98
+msgid "About"
+msgstr ""
+
+#: prefs.ui:118
 msgid ""
 "© 2021 Stuart Hayhurst\n"
 "Licensed under <a href=\"https://www.gnu.org/licenses/gpl-3.0-standalone.html"
@@ -68,6 +88,6 @@ msgid ""
 "extension\">GitHub</a>"
 msgstr ""
 
-#: prefs.ui:125
+#: prefs.ui:141
 msgid "General settings"
 msgstr ""

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-01 16:41+0100\n"
+"POT-Creation-Date: 2021-06-01 18:59+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -75,19 +75,10 @@ msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr ""
 
-#: prefs.ui:98
-msgid "About"
-msgstr ""
-
-#: prefs.ui:118
-msgid ""
-"© 2021 Stuart Hayhurst\n"
-"Licensed under <a href=\"https://www.gnu.org/licenses/gpl-3.0-standalone.html"
-"\">GPL v3.0</a>\n"
-"Contribute on <a href=\"https://github.com/stuarthayhurst/alphabetical-grid-"
-"extension\">GitHub</a>"
-msgstr ""
-
-#: prefs.ui:141
+#: prefs.ui:95
 msgid "General settings"
+msgstr ""
+
+#: prefs.ui:117
+msgid "About"
 msgstr ""

--- a/prefs.js
+++ b/prefs.js
@@ -1,6 +1,9 @@
-const {GObject, Gtk} = imports.gi;
+const {GObject, Gtk, GdkPixbuf} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
+//Use _() for translations
+const _ = imports.gettext.domain(Me.metadata.uuid).gettext;
 
 var PrefsWidget = class PrefsWidget {
   constructor() {
@@ -14,12 +17,31 @@ var PrefsWidget = class PrefsWidget {
     this.widget.add(this._builder.get_object('main-prefs'));
 
     this._foldersSwitch = this._builder.get_object('sort-folders-switch');
-
     //Set sliders to match the gsettings vlaues for the extension
     this._updateSwitch(this._foldersSwitch, 'sort-folder-contents');
-
     //Update gsettings values when switches are toggled
     this._listenForChanges(this._foldersSwitch, 'sort-folder-contents');
+
+    //Create about menu when button is pressed
+    this._aboutButton = this._builder.get_object('about-button');
+    this._aboutButton.connect('clicked', () => {
+      let aboutDialog = new Gtk.AboutDialog({
+        authors: [
+          'Stuart Hayhurst <stuart.a.hayhurst@gmail.com>'
+        ],
+        translator_credits: 'Philipp Kiemle <philipp.kiemle@gmail.com>',
+        program_name: _('Alphabetical App Grid'),
+        comments: _('Restore the alphabetical ordering of the app grid'),
+        license_type: Gtk.License.GPL_3_0,
+        copyright: _('© 2021 Stuart Hayhurst'),
+        logo: GdkPixbuf.Pixbuf.new_from_file_at_size(Me.path + '/icon.svg', 128, 128),
+        version: 'v' + Me.metadata.version.toString(),
+        website: Me.metadata.url.toString(),
+        website_label: _('Contribute on GitHub'),
+        modal: true
+      });
+      aboutDialog.present();
+    });
   }
 
   _listenForChanges(targetSwitch, gsettingsKey) {

--- a/prefs.ui
+++ b/prefs.ui
@@ -88,52 +88,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="hexpand">True</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkButton" id="about-button">
-                <property name="label" translatable="yes">About</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="halign">center</property>
-                <property name="valign">end</property>
-                <property name="margin-bottom">4</property>
-                <property name="vexpand">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="copyright-notice">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="valign">end</property>
-                <property name="label" translatable="yes">© 2021 Stuart Hayhurst
-Licensed under &lt;a href="https://www.gnu.org/licenses/gpl-3.0-standalone.html"&gt;GPL v3.0&lt;/a&gt;
-Contribute on &lt;a href="https://github.com/stuarthayhurst/alphabetical-grid-extension"&gt;GitHub&lt;/a&gt;</property>
-                <property name="use-markup">True</property>
-                <property name="justify">center</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">2</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel" id="settings-title">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -148,6 +102,36 @@ Contribute on &lt;a href="https://github.com/stuarthayhurst/alphabetical-grid-ex
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="margin-top">4</property>
+            <property name="hexpand">True</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkButton" id="about-button">
+                <property name="label" translatable="yes">About</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="halign">center</property>
+                <property name="valign">end</property>
+                <property name="vexpand">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">2</property>
           </packing>
         </child>
       </object>

--- a/prefs.ui
+++ b/prefs.ui
@@ -94,11 +94,27 @@
             <property name="hexpand">True</property>
             <property name="orientation">vertical</property>
             <child>
+              <object class="GtkButton" id="about-button">
+                <property name="label" translatable="yes">About</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="halign">center</property>
+                <property name="valign">end</property>
+                <property name="margin-bottom">4</property>
+                <property name="vexpand">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel" id="copyright-notice">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="valign">end</property>
-                <property name="vexpand">True</property>
                 <property name="label" translatable="yes">© 2021 Stuart Hayhurst
 Licensed under &lt;a href="https://www.gnu.org/licenses/gpl-3.0-standalone.html"&gt;GPL v3.0&lt;/a&gt;
 Contribute on &lt;a href="https://github.com/stuarthayhurst/alphabetical-grid-extension"&gt;GitHub&lt;/a&gt;</property>
@@ -108,7 +124,7 @@ Contribute on &lt;a href="https://github.com/stuarthayhurst/alphabetical-grid-ex
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
## Changes:
 - Adds 7 new translation strings (sorry)
 - Adds an 'About' page to the settings menu that displays credits, a GitHub link, an icon, extension name, description, version and license information

@daPhipz 
The main reason for making a pull request on my own repository was to check that you're okay with your name and email on display on the about page, as you're listed as a translator. If you're okay with that, I'll merge this pr.

![image](https://user-images.githubusercontent.com/33733427/120352772-07e49c00-c2f9-11eb-9b64-99933a517de0.png)
![image](https://user-images.githubusercontent.com/33733427/120352783-0b782300-c2f9-11eb-9d0c-aed55acb56f8.png)
![image](https://user-images.githubusercontent.com/33733427/120352805-103cd700-c2f9-11eb-9bfd-9e10927dce83.png)