### PR TITLE
Reorganise settings menu header bar

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-01 20:59+0200\n"
+"POT-Creation-Date: 2021-06-03 09:14+0100\n"
 "PO-Revision-Date: 2021-06-01 21:00+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -76,21 +76,25 @@ msgstr "© 2021 Stuart Hayhurst"
 msgid "Contribute on GitHub"
 msgstr "Mitwirken auf GitHub"
 
-#: prefs.ui:27
+#: prefs.js:75
+msgid "About"
+msgstr "Info"
+
+#: prefs.js:82
+msgid "Alphabetical App Grid Preferences"
+msgstr ""
+
+#: prefs.ui:28
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
 "Legt fest, ob Ordnerinhalte ebenfalls alphabetisch geordnet werden sollen"
 
-#: prefs.ui:46
+#: prefs.ui:47
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Ordnerinhalt sortieren"
 
-#: prefs.ui:95
+#: prefs.ui:96
 msgid "General settings"
 msgstr "Allgemeine Einstellungen"
-
-#: prefs.ui:117
-msgid "About"
-msgstr "Info"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-01 20:59+0200\n"
+"POT-Creation-Date: 2021-06-03 09:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,20 +72,24 @@ msgstr ""
 msgid "Contribute on GitHub"
 msgstr ""
 
-#: prefs.ui:27
+#: prefs.js:75
+msgid "About"
+msgstr ""
+
+#: prefs.js:82
+msgid "Alphabetical App Grid Preferences"
+msgstr ""
+
+#: prefs.ui:28
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
 
-#: prefs.ui:46
+#: prefs.ui:47
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr ""
 
-#: prefs.ui:95
+#: prefs.ui:96
 msgid "General settings"
-msgstr ""
-
-#: prefs.ui:117
-msgid "About"
 msgstr ""

--- a/prefs.js
+++ b/prefs.js
@@ -1,4 +1,4 @@
-const {GObject, Gtk, GdkPixbuf} = imports.gi;
+const {GObject, Gtk, GdkPixbuf, GLib} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
@@ -21,30 +21,29 @@ var PrefsWidget = class PrefsWidget {
     this._updateSwitch(this._foldersSwitch, 'sort-folder-contents');
     //Update gsettings values when switches are toggled
     this._listenForChanges(this._foldersSwitch, 'sort-folder-contents');
+  }
 
-    //Create about menu when button is pressed
-    this._aboutButton = this._builder.get_object('about-button');
-    this._aboutButton.connect('clicked', () => {
-      let aboutDialog = new Gtk.AboutDialog({
-        authors: [
-          'Stuart Hayhurst <stuart.a.hayhurst@gmail.com>'
-        ],
-        //Translators: Do not translate literally. If you want, you can enter your
-        //contact details here: "FIRSTNAME LASTNAME <email@addre.ss>, YEAR."
-        //If not, "translate" this string with a whitespace character.
-        translator_credits: _('translator-credits'),
-        program_name: _('Alphabetical App Grid'),
-        comments: _('Restore the alphabetical ordering of the app grid'),
-        license_type: Gtk.License.GPL_3_0,
-        copyright: _('© 2021 Stuart Hayhurst'),
-        logo: GdkPixbuf.Pixbuf.new_from_file_at_size(Me.path + '/icon.svg', 128, 128),
-        version: 'v' + Me.metadata.version.toString(),
-        website: Me.metadata.url.toString(),
-        website_label: _('Contribute on GitHub'),
-        modal: true
-      });
-      aboutDialog.present();
+  showAbout() {
+    //Create and display an about menu when requested
+    let aboutDialog = new Gtk.AboutDialog({
+      authors: [
+        'Stuart Hayhurst <stuart.a.hayhurst@gmail.com>'
+      ],
+      //Translators: Do not translate literally. If you want, you can enter your
+      //contact details here: "FIRSTNAME LASTNAME <email@addre.ss>, YEAR."
+      //If not, "translate" this string with a whitespace character.
+      translator_credits: _('translator-credits'),
+      program_name: _('Alphabetical App Grid'),
+      comments: _('Restore the alphabetical ordering of the app grid'),
+      license_type: Gtk.License.GPL_3_0,
+      copyright: _('© 2021 Stuart Hayhurst'),
+      logo: GdkPixbuf.Pixbuf.new_from_file_at_size(Me.path + '/icon.svg', 128, 128),
+      version: 'v' + Me.metadata.version.toString(),
+      website: Me.metadata.url.toString(),
+      website_label: _('Contribute on GitHub'),
+      modal: true
     });
+    aboutDialog.present();
   }
 
   _listenForChanges(targetSwitch, gsettingsKey) {
@@ -65,7 +64,27 @@ function init() {
 }
 
 function buildPrefsWidget() {
-  let settings = new PrefsWidget();
-  settings.widget.show_all();
-  return settings.widget;
+  let settingsMenu = new PrefsWidget();
+  settingsMenu.widget.show_all();
+
+  GLib.timeout_add(0, 0, () => {
+    let window = settingsMenu.widget.get_toplevel();
+    let headerBar = window.get_titlebar();
+
+    //Create a button on the header bar and show the about menu when clicked
+    let aboutButton = Gtk.Button.new_with_label(_('About'));
+    //let aboutButton = Gtk.Button.new_from_icon_name('dialog-information-symbolic', 16);
+    aboutButton.connect('clicked', () => {
+      settingsMenu.showAbout();
+    });
+
+    //Modify header bar title and add about menu button
+    headerBar.title = _('Alphabetical App Grid Preferences');
+    headerBar.pack_start(aboutButton);
+    aboutButton.show_all();
+
+    return GLib.SOURCE_REMOVE;
+  });
+
+  return settingsMenu.widget;
 }

--- a/prefs.js
+++ b/prefs.js
@@ -73,7 +73,6 @@ function buildPrefsWidget() {
 
     //Create a button on the header bar and show the about menu when clicked
     let aboutButton = Gtk.Button.new_with_label(_('About'));
-    //let aboutButton = Gtk.Button.new_from_icon_name('dialog-information-symbolic', 16);
     aboutButton.connect('clicked', () => {
       settingsMenu.showAbout();
     });

--- a/prefs.ui
+++ b/prefs.ui
@@ -9,12 +9,13 @@
     <property name="margin-bottom">10</property>
     <property name="orientation">vertical</property>
     <child>
-      <!-- n-columns=1 n-rows=3 -->
+      <!-- n-columns=1 n-rows=2 -->
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
+        <property name="column-homogeneous">True</property>
         <child>
           <object class="GtkListBox">
             <property name="visible">True</property>
@@ -102,36 +103,6 @@
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">start</property>
-            <property name="margin-top">4</property>
-            <property name="hexpand">True</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkButton" id="about-button">
-                <property name="label" translatable="yes">About</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="halign">center</property>
-                <property name="valign">end</property>
-                <property name="vexpand">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">2</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
## Changes:
 - Made title translatable
 - Moved about button to header bar

![image](https://user-images.githubusercontent.com/33733427/120611960-99185780-c44c-11eb-9063-521619175024.png)

After setting the button to have 'About' as a label, I'm not sure if we even need to set it to the icon instead. The icon code is still in there just commented out. To enable it, replace:
```
    let aboutButton = Gtk.Button.new_with_label(_('About'));
    //let aboutButton = Gtk.Button.new_from_icon_name('dialog-information-symbolic', 16);
```
> with
```
    //let aboutButton = Gtk.Button.new_with_label(_('About'));
    let aboutButton = Gtk.Button.new_from_icon_name('dialog-information-symbolic', 16);
```

If we decide to leave the button as is, I can merge after the translation and removing the commented line :)