### PR TITLE
Update German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-08-26 19:52+0100\n"
-"PO-Revision-Date: 2021-08-04 10:55+0200\n"
+"PO-Revision-Date: 2021-08-27 21:26+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
 "Language: de\n"
@@ -16,29 +16,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 3.0\n"
 
 #: extension.js:28
-#, fuzzy
-#| msgid "Reordered grid"
 msgid "Reordering app grid"
-msgstr "Raster wurde neu geordnet"
+msgstr "Raster wird neu geordnet"
 
 #: extension.js:81
 msgid "Patched item comparison"
-msgstr ""
+msgstr "Itemvergleich-Methode gepatched"
 
 #: extension.js:84
 msgid "Patched redisplay"
-msgstr ""
+msgstr "Redisplay-Methode gepatched"
 
 #: extension.js:90
 msgid "Unpatched item comparison"
-msgstr ""
+msgstr "Itemvergleich-Methode entpatched"
 
 #: extension.js:93
 msgid "Unpatched redisplay"
-msgstr ""
+msgstr "Redisplay-Methode entpatched"
 
 #: extension.js:106
 msgid "Reordering folder contents"
@@ -192,17 +190,16 @@ msgid "Position of ordered folders"
 msgstr "Ordnerposition"
 
 #: ui/prefs-gtk4.ui:269 ui/prefs.ui:425
-#, fuzzy
-#| msgid "General settings"
 msgid "Developer settings"
-msgstr "Allgemeine Einstellungen"
+msgstr "Entwickleroptionen"
 
 #: ui/prefs-gtk4.ui:287 ui/prefs.ui:461
 msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr ""
+"Legt fest, ob die Erweiterung Nachrichten an die Systemprotokolle sendet"
 
 #: ui/prefs-gtk4.ui:301 ui/prefs.ui:480
 msgctxt "setting-name"
 msgid "Enable extension logging"
-msgstr ""
+msgstr "Protokollierung aktivieren"


### PR DESCRIPTION
There you go!
I kind of "Denglish"ed the (un)patching log messages, because I think that they are only read by tech-savvy people (who understand English) anyway - since they are found nowhere in the UI.

I think I'll have a look at how to add a `msgctxt` outside of Glade, so that maybe we can mark all log messages with `log-message` or something, to make it clear that they won't appear to the "normal user". And maybe I'll add some explaining comments about the strings as well, since I had to ask you some questions about the new strings :)
This will make it easier for new contributors.

What do you think?