### PR TITLE
L10n improvements

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,6 +16,7 @@ Gettext.bindtextdomain(Me.metadata.uuid, ExtensionSystem.extensionMeta[Me.metada
 
 //Use _() for translations
 const _ = Gettext.gettext;
+const C_ = Gettext.pgettext;
 
 //Access required objects and systems
 const AppDisplay = ShellVersion < 40 ? Main.overview.viewSelector.appDisplay : Main.overview._overview._controls._appDisplay;
@@ -30,7 +31,7 @@ function enable() {
 
   //Patch shell, reorder and trigger listeners
   gridReorder.patchShell();
-  gridReorder.reorderGrid(Gettext.pgettext('log-message','Reordering app grid'));
+  gridReorder.reorderGrid(C_('log-message','Reordering app grid'));
   gridReorder.startListeners();
 }
 
@@ -84,22 +85,22 @@ class Extension {
     //Actually patch the internal functions
     AppDisplay._compareItems = _patchedCompareItems;
     //Translators: The extension now uses its own method to compare the items in the app grid.
-    ExtensionHelper.logMessage(Gettext.pgettext('log-message','Patched item comparison'));
+    ExtensionHelper.logMessage(C_('log-message','Patched item comparison'));
 
     AppDisplay._redisplay = _patchedRedisplay;
     //Translators: The extension now uses its own method to display the items in the app grid.
-    ExtensionHelper.logMessage(Gettext.pgettext('log-message','Patched redisplay'));
+    ExtensionHelper.logMessage(C_('log-message','Patched redisplay'));
   }
 
   unpatchShell() {
     //Unpatch the internal functions for extension shutdown
     AppDisplay._compareItems = this._originalCompareItems;
     //Translators: The extension now uses the system method to compare the items in the app grid.
-    ExtensionHelper.logMessage(Gettext.pgettext('log-message','Unpatched item comparison'));
+    ExtensionHelper.logMessage(C_('log-message','Unpatched item comparison'));
 
     AppDisplay._redisplay = this._originalRedisplay;
     //Translators: The extension now uses the system method to display the items in the app grid.
-    ExtensionHelper.logMessage(Gettext.pgettext('log-message','Unpatched redisplay'));
+    ExtensionHelper.logMessage(C_('log-message','Unpatched redisplay'));
   }
 
   //Helper functions
@@ -112,7 +113,7 @@ class Extension {
 
       //Alphabetically order the contents of each folder, if enabled
       if (this.extensionSettings.get_boolean('sort-folder-contents')) {
-        ExtensionHelper.logMessage(Gettext.pgettext('log-message','Reordering folder contents'));
+        ExtensionHelper.logMessage(C_('log-message','Reordering folder contents'));
         AppGridHelper.reorderFolderContents();
       }
 
@@ -145,23 +146,23 @@ class Extension {
 
     if (currentState == targetState) { //Do nothing if the current state and target state match
       if (currentState) {
-        ExtensionHelper.logMessage(Gettext.pgettext('log-message','Favourite apps are already shown'));
+        ExtensionHelper.logMessage(C_('log-message','Favourite apps are already shown'));
       } else {
-        ExtensionHelper.logMessage(Gettext.pgettext('log-message','Favourite apps are already hidden'));
+        ExtensionHelper.logMessage(C_('log-message','Favourite apps are already hidden'));
       }
       return;
 
     } else if (targetState) { //Show favourite apps, by patching _loadApps()
-      ExtensionHelper.logMessage(Gettext.pgettext('log-message','Showing favourite apps on the app grid'));
+      ExtensionHelper.logMessage(C_('log-message','Showing favourite apps on the app grid'));
       AppDisplay._loadApps = _patchedLoadApps;
     } else { //Hide favourite apps, by restoring _loadApps()
-      ExtensionHelper.logMessage(Gettext.pgettext('log-message','Hiding favourite apps on the app grid'));
+      ExtensionHelper.logMessage(C_('log-message','Hiding favourite apps on the app grid'));
       AppDisplay._loadApps = originalLoadApps;
     }
     this._favouriteAppsShown = targetState;
 
     //Trigger reorder with new changes
-    this.reorderGrid(Gettext.pgettext('log-message','Reordering app grid, due to favourite apps'));
+    this.reorderGrid(C_('log-message','Reordering app grid, due to favourite apps'));
   }
 
   //Listener functions below
@@ -178,7 +179,7 @@ class Extension {
       this._handleShowFavouriteApps();
     }
 
-    ExtensionHelper.logMessage(Gettext.pgettext('log-message','Connected to listeners'))
+    ExtensionHelper.logMessage(C_('log-message','Connected to listeners'))
   }
 
   disconnectListeners() {
@@ -192,7 +193,7 @@ class Extension {
     this.extensionSettings.disconnect(this._showFavouritesSignal);
     this.setShowFavouriteApps(false);
 
-    ExtensionHelper.logMessage(Gettext.pgettext('log-message','Disconnected from listeners'))
+    ExtensionHelper.logMessage(C_('log-message','Disconnected from listeners'))
   }
 
   _handleShowFavouriteApps() {
@@ -207,14 +208,14 @@ class Extension {
   _waitForExternalReorder() {
     //Connect to gsettings and wait for the order to change
     this._reorderSignal = this.shellSettings.connect('changed::app-picker-layout', () => {
-      this.reorderGrid(Gettext.pgettext('log-message','App grid layout changed, triggering reorder'));
+      this.reorderGrid(C_('log-message','App grid layout changed, triggering reorder'));
     });
   }
 
   _waitForFavouritesChange() {
     //Connect to gsettings and wait for the favourite apps to change
     this._favouriteAppsSignal = this.shellSettings.connect('changed::favorite-apps', () => {
-      this.reorderGrid(Gettext.pgettext('log-message','Favourite apps changed, triggering reorder'));
+      this.reorderGrid(C_('log-message','Favourite apps changed, triggering reorder'));
     });
   }
 
@@ -222,21 +223,21 @@ class Extension {
     //Connect to gsettings and wait for the extension's settings to change
     this._settingsChangedSignal = this.extensionSettings.connect('changed', () => {
       ExtensionHelper.loggingEnabled = Me.metadata.debug || this.extensionSettings.get_boolean('logging-enabled');
-      this.reorderGrid(Gettext.pgettext('log-message','Extension gsettings values changed, triggering reorder'));
+      this.reorderGrid(C_('log-message','Extension gsettings values changed, triggering reorder'));
     });
   }
 
   _waitForFolderChange() {
     //If a folder was made or deleted, trigger a reorder
     this._foldersChangedSignal = this.folderSettings.connect('changed::folder-children', () => {
-      this.reorderGrid(Gettext.pgettext('log-message','Folders changed, triggering reorder'));
+      this.reorderGrid(C_('log-message','Folders changed, triggering reorder'));
     });
   }
 
   _waitForInstalledAppsChange() {
     //Wait for installed apps to change
     this._installedAppsChangedSignal = Shell.AppSystem.get_default().connect('installed-changed', () => {
-      this.reorderGrid(Gettext.pgettext('log-message','Installed apps changed, triggering reorder'));
+      this.reorderGrid(C_('log-message','Installed apps changed, triggering reorder'));
     });
   }
 }

--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,7 @@ function enable() {
 
   //Patch shell, reorder and trigger listeners
   gridReorder.patchShell();
-  gridReorder.reorderGrid(C_('log-message','Reordering app grid'));
+  gridReorder.reorderGrid(C_('log-message', 'Reordering app grid'));
   gridReorder.startListeners();
 }
 
@@ -84,22 +84,22 @@ class Extension {
     //Actually patch the internal functions
     AppDisplay._compareItems = _patchedCompareItems;
     //Translators: The extension now uses its own method to compare the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message','Patched item comparison'));
+    ExtensionHelper.logMessage(C_('log-message', 'Patched item comparison'));
 
     AppDisplay._redisplay = _patchedRedisplay;
     //Translators: The extension now uses its own method to display the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message','Patched redisplay'));
+    ExtensionHelper.logMessage(C_('log-message', 'Patched redisplay'));
   }
 
   unpatchShell() {
     //Unpatch the internal functions for extension shutdown
     AppDisplay._compareItems = this._originalCompareItems;
     //Translators: The extension now uses the system method to compare the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message','Unpatched item comparison'));
+    ExtensionHelper.logMessage(C_('log-message', 'Unpatched item comparison'));
 
     AppDisplay._redisplay = this._originalRedisplay;
     //Translators: The extension now uses the system method to display the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message','Unpatched redisplay'));
+    ExtensionHelper.logMessage(C_('log-message', 'Unpatched redisplay'));
   }
 
   //Helper functions
@@ -112,7 +112,7 @@ class Extension {
 
       //Alphabetically order the contents of each folder, if enabled
       if (this.extensionSettings.get_boolean('sort-folder-contents')) {
-        ExtensionHelper.logMessage(C_('log-message','Reordering folder contents'));
+        ExtensionHelper.logMessage(C_('log-message', 'Reordering folder contents'));
         AppGridHelper.reorderFolderContents();
       }
 
@@ -145,23 +145,23 @@ class Extension {
 
     if (currentState == targetState) { //Do nothing if the current state and target state match
       if (currentState) {
-        ExtensionHelper.logMessage(C_('log-message','Favourite apps are already shown'));
+        ExtensionHelper.logMessage(C_('log-message', 'Favourite apps are already shown'));
       } else {
-        ExtensionHelper.logMessage(C_('log-message','Favourite apps are already hidden'));
+        ExtensionHelper.logMessage(C_('log-message', 'Favourite apps are already hidden'));
       }
       return;
 
     } else if (targetState) { //Show favourite apps, by patching _loadApps()
-      ExtensionHelper.logMessage(C_('log-message','Showing favourite apps on the app grid'));
+      ExtensionHelper.logMessage(C_('log-message', 'Showing favourite apps on the app grid'));
       AppDisplay._loadApps = _patchedLoadApps;
     } else { //Hide favourite apps, by restoring _loadApps()
-      ExtensionHelper.logMessage(C_('log-message','Hiding favourite apps on the app grid'));
+      ExtensionHelper.logMessage(C_('log-message', 'Hiding favourite apps on the app grid'));
       AppDisplay._loadApps = originalLoadApps;
     }
     this._favouriteAppsShown = targetState;
 
     //Trigger reorder with new changes
-    this.reorderGrid(C_('log-message','Reordering app grid, due to favourite apps'));
+    this.reorderGrid(C_('log-message', 'Reordering app grid, due to favourite apps'));
   }
 
   //Listener functions below
@@ -178,7 +178,7 @@ class Extension {
       this._handleShowFavouriteApps();
     }
 
-    ExtensionHelper.logMessage(C_('log-message','Connected to listeners'))
+    ExtensionHelper.logMessage(C_('log-message', 'Connected to listeners'))
   }
 
   disconnectListeners() {
@@ -192,7 +192,7 @@ class Extension {
     this.extensionSettings.disconnect(this._showFavouritesSignal);
     this.setShowFavouriteApps(false);
 
-    ExtensionHelper.logMessage(C_('log-message','Disconnected from listeners'))
+    ExtensionHelper.logMessage(C_('log-message', 'Disconnected from listeners'))
   }
 
   _handleShowFavouriteApps() {
@@ -207,14 +207,14 @@ class Extension {
   _waitForExternalReorder() {
     //Connect to gsettings and wait for the order to change
     this._reorderSignal = this.shellSettings.connect('changed::app-picker-layout', () => {
-      this.reorderGrid(C_('log-message','App grid layout changed, triggering reorder'));
+      this.reorderGrid(C_('log-message', 'App grid layout changed, triggering reorder'));
     });
   }
 
   _waitForFavouritesChange() {
     //Connect to gsettings and wait for the favourite apps to change
     this._favouriteAppsSignal = this.shellSettings.connect('changed::favorite-apps', () => {
-      this.reorderGrid(C_('log-message','Favourite apps changed, triggering reorder'));
+      this.reorderGrid(C_('log-message', 'Favourite apps changed, triggering reorder'));
     });
   }
 
@@ -222,21 +222,21 @@ class Extension {
     //Connect to gsettings and wait for the extension's settings to change
     this._settingsChangedSignal = this.extensionSettings.connect('changed', () => {
       ExtensionHelper.loggingEnabled = Me.metadata.debug || this.extensionSettings.get_boolean('logging-enabled');
-      this.reorderGrid(C_('log-message','Extension gsettings values changed, triggering reorder'));
+      this.reorderGrid(C_('log-message', 'Extension gsettings values changed, triggering reorder'));
     });
   }
 
   _waitForFolderChange() {
     //If a folder was made or deleted, trigger a reorder
     this._foldersChangedSignal = this.folderSettings.connect('changed::folder-children', () => {
-      this.reorderGrid(C_('log-message','Folders changed, triggering reorder'));
+      this.reorderGrid(C_('log-message', 'Folders changed, triggering reorder'));
     });
   }
 
   _waitForInstalledAppsChange() {
     //Wait for installed apps to change
     this._installedAppsChangedSignal = Shell.AppSystem.get_default().connect('installed-changed', () => {
-      this.reorderGrid(C_('log-message','Installed apps changed, triggering reorder'));
+      this.reorderGrid(C_('log-message', 'Installed apps changed, triggering reorder'));
     });
   }
 }

--- a/extension.js
+++ b/extension.js
@@ -14,7 +14,7 @@ const Gettext = imports.gettext;
 Gettext.textdomain(Me.metadata.uuid);
 Gettext.bindtextdomain(Me.metadata.uuid, ExtensionSystem.extensionMeta[Me.metadata.uuid].path + "/locale");
 
-//Use _() for translations
+//Use C_() for translations
 const C_ = Gettext.pgettext;
 
 //Access required objects and systems

--- a/extension.js
+++ b/extension.js
@@ -12,8 +12,8 @@ const ParentalControlsManager = imports.misc.parentalControlsManager;
 //Access required objects and systems
 const AppDisplay = ShellVersion < 40 ? Main.overview.viewSelector.appDisplay : Main.overview._overview._controls._appDisplay;
 
-//Use C_() for translations
-const C_ = imports.gettext.domain(Me.metadata.uuid).pgettext;
+//Use _() for translations
+const _ = imports.gettext.domain(Me.metadata.uuid).gettext;
 
 function init() {
   ExtensionUtils.initTranslations();
@@ -25,7 +25,7 @@ function enable() {
 
   //Patch shell, reorder and trigger listeners
   gridReorder.patchShell();
-  gridReorder.reorderGrid(C_('log-message', 'Reordering app grid'));
+  gridReorder.reorderGrid(_('Reordering app grid'));
   gridReorder.startListeners();
 }
 
@@ -79,22 +79,22 @@ class Extension {
     //Actually patch the internal functions
     AppDisplay._compareItems = _patchedCompareItems;
     //Translators: The extension now uses its own method to compare the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message', 'Patched item comparison'));
+    ExtensionHelper.logMessage(_('Patched item comparison'));
 
     AppDisplay._redisplay = _patchedRedisplay;
     //Translators: The extension now uses its own method to display the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message', 'Patched redisplay'));
+    ExtensionHelper.logMessage(_('Patched redisplay'));
   }
 
   unpatchShell() {
     //Unpatch the internal functions for extension shutdown
     AppDisplay._compareItems = this._originalCompareItems;
     //Translators: The extension now uses the system method to compare the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message', 'Unpatched item comparison'));
+    ExtensionHelper.logMessage(_('Unpatched item comparison'));
 
     AppDisplay._redisplay = this._originalRedisplay;
     //Translators: The extension now uses the system method to display the items in the app grid.
-    ExtensionHelper.logMessage(C_('log-message', 'Unpatched redisplay'));
+    ExtensionHelper.logMessage(_('Unpatched redisplay'));
   }
 
   //Helper functions
@@ -107,7 +107,7 @@ class Extension {
 
       //Alphabetically order the contents of each folder, if enabled
       if (this.extensionSettings.get_boolean('sort-folder-contents')) {
-        ExtensionHelper.logMessage(C_('log-message', 'Reordering folder contents'));
+        ExtensionHelper.logMessage(_('Reordering folder contents'));
         AppGridHelper.reorderFolderContents();
       }
 
@@ -140,23 +140,23 @@ class Extension {
 
     if (currentState == targetState) { //Do nothing if the current state and target state match
       if (currentState) {
-        ExtensionHelper.logMessage(C_('log-message', 'Favourite apps are already shown'));
+        ExtensionHelper.logMessage(_('Favourite apps are already shown'));
       } else {
-        ExtensionHelper.logMessage(C_('log-message', 'Favourite apps are already hidden'));
+        ExtensionHelper.logMessage(_('Favourite apps are already hidden'));
       }
       return;
 
     } else if (targetState) { //Show favourite apps, by patching _loadApps()
-      ExtensionHelper.logMessage(C_('log-message', 'Showing favourite apps on the app grid'));
+      ExtensionHelper.logMessage(_('Showing favourite apps on the app grid'));
       AppDisplay._loadApps = _patchedLoadApps;
     } else { //Hide favourite apps, by restoring _loadApps()
-      ExtensionHelper.logMessage(C_('log-message', 'Hiding favourite apps on the app grid'));
+      ExtensionHelper.logMessage(_('Hiding favourite apps on the app grid'));
       AppDisplay._loadApps = originalLoadApps;
     }
     this._favouriteAppsShown = targetState;
 
     //Trigger reorder with new changes
-    this.reorderGrid(C_('log-message', 'Reordering app grid, due to favourite apps'));
+    this.reorderGrid(_('Reordering app grid, due to favourite apps'));
   }
 
   //Listener functions below
@@ -173,7 +173,7 @@ class Extension {
       this._handleShowFavouriteApps();
     }
 
-    ExtensionHelper.logMessage(C_('log-message', 'Connected to listeners'))
+    ExtensionHelper.logMessage(_('Connected to listeners'))
   }
 
   disconnectListeners() {
@@ -187,7 +187,7 @@ class Extension {
     this.extensionSettings.disconnect(this._showFavouritesSignal);
     this.setShowFavouriteApps(false);
 
-    ExtensionHelper.logMessage(C_('log-message', 'Disconnected from listeners'))
+    ExtensionHelper.logMessage(_('Disconnected from listeners'))
   }
 
   _handleShowFavouriteApps() {
@@ -202,14 +202,14 @@ class Extension {
   _waitForExternalReorder() {
     //Connect to gsettings and wait for the order to change
     this._reorderSignal = this.shellSettings.connect('changed::app-picker-layout', () => {
-      this.reorderGrid(C_('log-message', 'App grid layout changed, triggering reorder'));
+      this.reorderGrid(_('App grid layout changed, triggering reorder'));
     });
   }
 
   _waitForFavouritesChange() {
     //Connect to gsettings and wait for the favourite apps to change
     this._favouriteAppsSignal = this.shellSettings.connect('changed::favorite-apps', () => {
-      this.reorderGrid(C_('log-message', 'Favourite apps changed, triggering reorder'));
+      this.reorderGrid(_('Favourite apps changed, triggering reorder'));
     });
   }
 
@@ -217,21 +217,21 @@ class Extension {
     //Connect to gsettings and wait for the extension's settings to change
     this._settingsChangedSignal = this.extensionSettings.connect('changed', () => {
       ExtensionHelper.loggingEnabled = Me.metadata.debug || this.extensionSettings.get_boolean('logging-enabled');
-      this.reorderGrid(C_('log-message', 'Extension gsettings values changed, triggering reorder'));
+      this.reorderGrid(_('Extension gsettings values changed, triggering reorder'));
     });
   }
 
   _waitForFolderChange() {
     //If a folder was made or deleted, trigger a reorder
     this._foldersChangedSignal = this.folderSettings.connect('changed::folder-children', () => {
-      this.reorderGrid(C_('log-message', 'Folders changed, triggering reorder'));
+      this.reorderGrid(_('Folders changed, triggering reorder'));
     });
   }
 
   _waitForInstalledAppsChange() {
     //Wait for installed apps to change
     this._installedAppsChangedSignal = Shell.AppSystem.get_default().connect('installed-changed', () => {
-      this.reorderGrid(C_('log-message', 'Installed apps changed, triggering reorder'));
+      this.reorderGrid(_('Installed apps changed, triggering reorder'));
     });
   }
 }

--- a/extension.js
+++ b/extension.js
@@ -83,18 +83,22 @@ class Extension {
 
     //Actually patch the internal functions
     AppDisplay._compareItems = _patchedCompareItems;
+    //Translators: The extension now uses its own method to compare the items in the app grid.
     ExtensionHelper.logMessage(Gettext.pgettext('log-message','Patched item comparison'));
 
     AppDisplay._redisplay = _patchedRedisplay;
+    //Translators: The extension now uses its own method to display the items in the app grid.
     ExtensionHelper.logMessage(Gettext.pgettext('log-message','Patched redisplay'));
   }
 
   unpatchShell() {
     //Unpatch the internal functions for extension shutdown
     AppDisplay._compareItems = this._originalCompareItems;
+    //Translators: The extension now uses the system method to compare the items in the app grid.
     ExtensionHelper.logMessage(Gettext.pgettext('log-message','Unpatched item comparison'));
 
     AppDisplay._redisplay = this._originalRedisplay;
+    //Translators: The extension now uses the system method to display the items in the app grid.
     ExtensionHelper.logMessage(Gettext.pgettext('log-message','Unpatched redisplay'));
   }
 

--- a/extension.js
+++ b/extension.js
@@ -15,7 +15,6 @@ Gettext.textdomain(Me.metadata.uuid);
 Gettext.bindtextdomain(Me.metadata.uuid, ExtensionSystem.extensionMeta[Me.metadata.uuid].path + "/locale");
 
 //Use _() for translations
-const _ = Gettext.gettext;
 const C_ = Gettext.pgettext;
 
 //Access required objects and systems

--- a/extension.js
+++ b/extension.js
@@ -78,22 +78,22 @@ class Extension {
 
     //Actually patch the internal functions
     AppDisplay._compareItems = _patchedCompareItems;
-    //Translators: The extension now uses its own method to compare the items in the app grid.
+    //Translators: This is a log message. The extension now uses its own method to compare the items in the app grid.
     ExtensionHelper.logMessage(_('Patched item comparison'));
 
     AppDisplay._redisplay = _patchedRedisplay;
-    //Translators: The extension now uses its own method to display the items in the app grid.
+    //Translators: This is a log message. The extension now uses its own method to display the items in the app grid.
     ExtensionHelper.logMessage(_('Patched redisplay'));
   }
 
   unpatchShell() {
     //Unpatch the internal functions for extension shutdown
     AppDisplay._compareItems = this._originalCompareItems;
-    //Translators: The extension now uses the system method to compare the items in the app grid.
+    //Translators: This is a log message. The extension now uses the system method to compare the items in the app grid.
     ExtensionHelper.logMessage(_('Unpatched item comparison'));
 
     AppDisplay._redisplay = this._originalRedisplay;
-    //Translators: The extension now uses the system method to display the items in the app grid.
+    //Translators: This is a log message. The extension now uses the system method to display the items in the app grid.
     ExtensionHelper.logMessage(_('Unpatched redisplay'));
   }
 

--- a/extension.js
+++ b/extension.js
@@ -9,16 +9,11 @@ const { GLib, Gio, Shell } = imports.gi;
 const Main = imports.ui.main;
 const ParentalControlsManager = imports.misc.parentalControlsManager;
 
-//Translation imports
-const Gettext = imports.gettext;
-Gettext.textdomain(Me.metadata.uuid);
-Gettext.bindtextdomain(Me.metadata.uuid, ExtensionSystem.extensionMeta[Me.metadata.uuid].path + "/locale");
-
-//Use C_() for translations
-const C_ = Gettext.pgettext;
-
 //Access required objects and systems
 const AppDisplay = ShellVersion < 40 ? Main.overview.viewSelector.appDisplay : Main.overview._overview._controls._appDisplay;
+
+//Use C_() for translations
+const C_ = imports.gettext.domain(Me.metadata.uuid).pgettext;
 
 function init() {
   ExtensionUtils.initTranslations();

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-26 19:52+0100\n"
-"PO-Revision-Date: 2021-08-27 21:26+0200\n"
+"POT-Creation-Date: 2021-08-30 12:51+0200\n"
+"PO-Revision-Date: 2021-08-30 12:58+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
 "Language: de\n"
@@ -19,76 +19,98 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 
 #: extension.js:28
+msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr "Raster wird neu geordnet"
 
-#: extension.js:81
+#. Translators: The extension now uses its own method to compare the items in the app grid.
+#: extension.js:82
+msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr "Itemvergleich-Methode gepatched"
 
-#: extension.js:84
+#. Translators: The extension now uses its own method to display the items in the app grid.
+#: extension.js:86
+msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr "Redisplay-Methode gepatched"
 
-#: extension.js:90
+#. Translators: The extension now uses the system method to compare the items in the app grid.
+#: extension.js:93
+msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr "Itemvergleich-Methode entpatched"
 
-#: extension.js:93
+#. Translators: The extension now uses the system method to display the items in the app grid.
+#: extension.js:97
+msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr "Redisplay-Methode entpatched"
 
-#: extension.js:106
+#: extension.js:110
+msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr "Ordnerinhalt wird neu geordnet"
 
-#: extension.js:139
+#: extension.js:143
+msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr "Favorisierte Anwendungen werden bereits angezeigt"
 
-#: extension.js:141
+#: extension.js:145
+msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr "Favorisierte Anwendungen werden bereits versteckt"
 
-#: extension.js:146
+#: extension.js:150
+msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr "Favorisierte Anwendungen werden im Raster angezeigt"
 
-#: extension.js:149
+#: extension.js:153
+msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr "Favorisierte Anwendungen werden im Raster versteckt"
 
-#: extension.js:155
+#: extension.js:159
+msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr ""
 "Anwendungsraster wird aufgrund der favorisierten Anwendungen neu geordnet"
 
-#: extension.js:172
+#: extension.js:176
+msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr "Mit Listenern verbunden"
 
-#: extension.js:186
+#: extension.js:190
+msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr "Von Listenern getrennt"
 
-#: extension.js:201
+#: extension.js:205
+msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr "Layout des Anwendungsrasters wurde geändert, Neuordung wird ausgelöst"
 
-#: extension.js:208
+#: extension.js:212
+msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr "Favorisierte Anwendungen wurden geändert, Neuordnung wird ausgelöst"
 
-#: extension.js:216
+#: extension.js:220
+msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 "gsettings-Werte der Erweiterung wurden geändert, Neuordnung wird ausgelöst"
 
-#: extension.js:223
+#: extension.js:227
+msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr "Ordner wurden geändert, Neuordnung wird ausgelöst"
 
-#: extension.js:230
+#: extension.js:234
+msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr "Installierte Anwendungen wurden geändert, Neuordnung wird ausgelöst"
 
@@ -123,22 +145,25 @@ msgstr "Info"
 msgid "Alphabetical App Grid Preferences"
 msgstr "Alphabetical App Grid-Einstellungen"
 
+#. Folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
 msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr "Alphabetisch"
 
+#. Folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
 msgctxt "folder-position"
 msgid "Start"
 msgstr "Anfang"
 
+#. Folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
 msgctxt "folder-position"
 msgid "End"
 msgstr "Ende"
 
-#: ui/prefs-gtk4.ui:41 ui/prefs.ui:53
+#: ui/prefs-gtk4.ui:45 ui/prefs.ui:53
 msgid ""
 "Found this useful?\n"
 "<a href=\"https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN"
@@ -148,58 +173,58 @@ msgstr ""
 "<a href=\"https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN"
 "\">Eine Spende wäre nett :)</a>"
 
-#: ui/prefs-gtk4.ui:68 ui/prefs.ui:93
+#: ui/prefs-gtk4.ui:76 ui/prefs.ui:93
 msgid "GNOME 40+ settings"
 msgstr "Einstellungen für GNOME 40+"
 
-#: ui/prefs-gtk4.ui:86 ui/prefs.ui:129
-msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
+#: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
+msgid "Allows displaying the favourite apps on the app grid"
 msgstr ""
 "Legt fest, ob favorisierte Anwendungen im Anwendungsraster angezeigt werden "
-"sollen (GNOME 40+)"
+"sollen"
 
-#: ui/prefs-gtk4.ui:100 ui/prefs.ui:148
+#: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
 msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr "Favorisierte Anwendungen im Raster anzeigen"
 
-#: ui/prefs-gtk4.ui:144 ui/prefs.ui:221
+#: ui/prefs-gtk4.ui:158 ui/prefs.ui:221
 msgid "General settings"
 msgstr "Allgemeine Einstellungen"
 
-#: ui/prefs-gtk4.ui:162 ui/prefs.ui:257
+#: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
 "Legt fest, ob Ordnerinhalte ebenfalls alphabetisch geordnet werden sollen"
 
-#: ui/prefs-gtk4.ui:176 ui/prefs.ui:276
+#: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Ordnerinhalt sortieren"
 
-#: ui/prefs-gtk4.ui:206 ui/prefs.ui:327
+#: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr ""
 "Legt fest, an welcher Stelle Ordner im Anwendungsraster angezeigt werden "
 "sollen"
 
-#: ui/prefs-gtk4.ui:220 ui/prefs.ui:346
+#: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
 msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr "Ordnerposition"
 
-#: ui/prefs-gtk4.ui:269 ui/prefs.ui:425
+#: ui/prefs-gtk4.ui:293 ui/prefs.ui:425
 msgid "Developer settings"
 msgstr "Entwickleroptionen"
 
-#: ui/prefs-gtk4.ui:287 ui/prefs.ui:461
+#: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
 msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr ""
 "Legt fest, ob die Erweiterung Nachrichten an die Systemprotokolle sendet"
 
-#: ui/prefs-gtk4.ui:301 ui/prefs.ui:480
+#: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
 msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr "Protokollierung aktivieren"

--- a/po/de.po
+++ b/po/de.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-30 12:51+0200\n"
-"PO-Revision-Date: 2021-08-30 12:58+0200\n"
+"POT-Creation-Date: 2021-08-31 13:30+0200\n"
+"PO-Revision-Date: 2021-08-31 13:22+0200\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
-"Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
+"Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,98 +19,80 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 
 #: extension.js:28
-msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr "Raster wird neu geordnet"
 
-#. Translators: The extension now uses its own method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to compare the items in the app grid.
 #: extension.js:82
-msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr "Itemvergleich-Methode gepatched"
 
-#. Translators: The extension now uses its own method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to display the items in the app grid.
 #: extension.js:86
-msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr "Redisplay-Methode gepatched"
 
-#. Translators: The extension now uses the system method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to compare the items in the app grid.
 #: extension.js:93
-msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr "Itemvergleich-Methode entpatched"
 
-#. Translators: The extension now uses the system method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to display the items in the app grid.
 #: extension.js:97
-msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr "Redisplay-Methode entpatched"
 
 #: extension.js:110
-msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr "Ordnerinhalt wird neu geordnet"
 
 #: extension.js:143
-msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr "Favorisierte Anwendungen werden bereits angezeigt"
 
 #: extension.js:145
-msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr "Favorisierte Anwendungen werden bereits versteckt"
 
 #: extension.js:150
-msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr "Favorisierte Anwendungen werden im Raster angezeigt"
 
 #: extension.js:153
-msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr "Favorisierte Anwendungen werden im Raster versteckt"
 
 #: extension.js:159
-msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr ""
 "Anwendungsraster wird aufgrund der favorisierten Anwendungen neu geordnet"
 
 #: extension.js:176
-msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr "Mit Listenern verbunden"
 
 #: extension.js:190
-msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr "Von Listenern getrennt"
 
 #: extension.js:205
-msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr "Layout des Anwendungsrasters wurde geändert, Neuordung wird ausgelöst"
 
 #: extension.js:212
-msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr "Favorisierte Anwendungen wurden geändert, Neuordnung wird ausgelöst"
 
 #: extension.js:220
-msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 "gsettings-Werte der Erweiterung wurden geändert, Neuordnung wird ausgelöst"
 
 #: extension.js:227
-msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr "Ordner wurden geändert, Neuordnung wird ausgelöst"
 
 #: extension.js:234
-msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr "Installierte Anwendungen wurden geändert, Neuordnung wird ausgelöst"
 
@@ -145,21 +127,20 @@ msgstr "Info"
 msgid "Alphabetical App Grid Preferences"
 msgstr "Alphabetical App Grid-Einstellungen"
 
-#. Folders will appear in alphabetical order, mixed with applications.
+#. When this is selected, folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
-msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr "Alphabetisch"
 
-#. Folders will appear at the beginning of the app grid, in front of the other apps.
+#. When this is selected, folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
-msgctxt "folder-position"
+msgctxt "position"
 msgid "Start"
 msgstr "Anfang"
 
-#. Folders will appear at the end of the app grid, behind the other apps.
+#. When this is selected, folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
-msgctxt "folder-position"
+msgctxt "position"
 msgid "End"
 msgstr "Ende"
 
@@ -177,6 +158,7 @@ msgstr ""
 msgid "GNOME 40+ settings"
 msgstr "Einstellungen für GNOME 40+"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
 msgid "Allows displaying the favourite apps on the app grid"
 msgstr ""
@@ -184,7 +166,6 @@ msgstr ""
 "sollen"
 
 #: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
-msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr "Favorisierte Anwendungen im Raster anzeigen"
 
@@ -192,25 +173,25 @@ msgstr "Favorisierte Anwendungen im Raster anzeigen"
 msgid "General settings"
 msgstr "Allgemeine Einstellungen"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
-msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
 "Legt fest, ob Ordnerinhalte ebenfalls alphabetisch geordnet werden sollen"
 
 #: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
-msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Ordnerinhalt sortieren"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr ""
 "Legt fest, an welcher Stelle Ordner im Anwendungsraster angezeigt werden "
 "sollen"
 
+#. Next to a dropdown with the options "Alphabetical", "Start" and "End".
 #: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
-msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr "Ordnerposition"
 
@@ -218,13 +199,12 @@ msgstr "Ordnerposition"
 msgid "Developer settings"
 msgstr "Entwickleroptionen"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
-msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr ""
 "Legt fest, ob die Erweiterung Nachrichten an die Systemprotokolle sendet"
 
 #: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
-msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr "Protokollierung aktivieren"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-29 15:13+0100\n"
+"POT-Creation-Date: 2021-08-30 12:51+0200\n"
 "PO-Revision-Date: 2021-08-29 14:42+0200\n"
 "Last-Translator: Alan <Alan90000@yahoo.com>\n"
 "Language-Team: \n"
@@ -18,80 +18,138 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 
 #: extension.js:28
+#, fuzzy
+#| msgid "Reordering app grid"
+msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr "Réorganisation de la grille d'applications"
 
-#: extension.js:81
+#. Translators: The extension now uses its own method to compare the items in the app grid.
+#: extension.js:82
+#, fuzzy
+#| msgid "Patched item comparison"
+msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr "Comparaison des éléments corrigés"
 
-#: extension.js:84
+#. Translators: The extension now uses its own method to display the items in the app grid.
+#: extension.js:86
+#, fuzzy
+#| msgid "Patched redisplay"
+msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr "Réaffichage corrigé"
 
-#: extension.js:90
+#. Translators: The extension now uses the system method to compare the items in the app grid.
+#: extension.js:93
+#, fuzzy
+#| msgid "Unpatched item comparison"
+msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr "Comparaison d'éléments non corrigés"
 
-#: extension.js:93
+#. Translators: The extension now uses the system method to display the items in the app grid.
+#: extension.js:97
+#, fuzzy
+#| msgid "Unpatched redisplay"
+msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr "Réaffichage non corrigé"
 
-#: extension.js:106
+#: extension.js:110
+#, fuzzy
+#| msgid "Reordering folder contents"
+msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr "Réorganisation du contenu du dossier"
 
-#: extension.js:139
+#: extension.js:143
+#, fuzzy
+#| msgid "Favourite apps are already shown"
+msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr "Les applications préférées sont déjà affichées"
 
-#: extension.js:141
+#: extension.js:145
+#, fuzzy
+#| msgid "Favourite apps are already hidden"
+msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr "Les applications préférées sont déjà masquées"
 
-#: extension.js:146
+#: extension.js:150
+#, fuzzy
+#| msgid "Showing favourite apps on the app grid"
+msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr "Affichage des applications préférées sur la grille d'applications"
 
-#: extension.js:149
+#: extension.js:153
+#, fuzzy
+#| msgid "Hiding favourite apps on the app grid"
+msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr "Masquer les applications préférées sur la grille d'applications"
 
-#: extension.js:155
+#: extension.js:159
+#, fuzzy
+#| msgid "Reordering app grid, due to favourite apps"
+msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr ""
 "Réorganisation de la grille d'applications, en raison des applications "
 "préférées"
 
-#: extension.js:172
+#: extension.js:176
+#, fuzzy
+#| msgid "Connected to listeners"
+msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr "Connecté aux auditeurs"
 
-#: extension.js:186
+#: extension.js:190
+#, fuzzy
+#| msgid "Disconnected from listeners"
+msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr "Déconnecté des auditeurs"
 
-#: extension.js:201
+#: extension.js:205
+#, fuzzy
+#| msgid "App grid layout changed, triggering reorder"
+msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr ""
 "La disposition de la grille d'applications a été modifiée, déclenchant la "
 "réorganisation"
 
-#: extension.js:208
+#: extension.js:212
+#, fuzzy
+#| msgid "Favourite apps changed, triggering reorder"
+msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr "Applications préférées modifiées, déclenchant une réorganisation"
 
-#: extension.js:216
+#: extension.js:220
+#, fuzzy
+#| msgid "Extension gsettings values changed, triggering reorder"
+msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 "Les valeurs des paramètres d'extension ont changé, déclenchant la "
 "réorganisation"
 
-#: extension.js:223
+#: extension.js:227
+#, fuzzy
+#| msgid "Folders changed, triggering reorder"
+msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr "Les dossiers ont été modifiés, déclenchant la réorganisation"
 
-#: extension.js:230
+#: extension.js:234
+#, fuzzy
+#| msgid "Installed apps changed, triggering reorder"
+msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr ""
 "Les applications installées ont été modifiées, déclenchant une réorganisation"
@@ -127,22 +185,25 @@ msgstr "À propos de"
 msgid "Alphabetical App Grid Preferences"
 msgstr "Préférences de grille d'applications alphabétique"
 
+#. Folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
 msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr "Alphabétique"
 
+#. Folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
 msgctxt "folder-position"
 msgid "Start"
 msgstr "Démarrer"
 
+#. Folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
 msgctxt "folder-position"
 msgid "End"
 msgstr "Fin"
 
-#: ui/prefs-gtk4.ui:41 ui/prefs.ui:53
+#: ui/prefs-gtk4.ui:45 ui/prefs.ui:53
 msgid ""
 "Found this useful?\n"
 "<a href=\"https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN"
@@ -152,55 +213,57 @@ msgstr ""
 "<a href=\"https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN"
 "\">Pensez à faire un don :)</a>"
 
-#: ui/prefs-gtk4.ui:68 ui/prefs.ui:93
+#: ui/prefs-gtk4.ui:76 ui/prefs.ui:93
 msgid "GNOME 40+ settings"
 msgstr "Paramètres GNOME 40+"
 
-#: ui/prefs-gtk4.ui:86 ui/prefs.ui:129
-msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
+#: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
+#, fuzzy
+#| msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
+msgid "Allows displaying the favourite apps on the app grid"
 msgstr ""
 "Permet d'afficher les applications préférées sur la grille d'applications "
 "(GNOME 40+)"
 
-#: ui/prefs-gtk4.ui:100 ui/prefs.ui:148
+#: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
 msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr "Afficher les applications préférées sur la grille d'applications"
 
-#: ui/prefs-gtk4.ui:144 ui/prefs.ui:221
+#: ui/prefs-gtk4.ui:158 ui/prefs.ui:221
 msgid "General settings"
 msgstr "Paramètres généraux"
 
-#: ui/prefs-gtk4.ui:162 ui/prefs.ui:257
+#: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr "Si le contenu des dossiers doit être trié par ordre alphabétique"
 
-#: ui/prefs-gtk4.ui:176 ui/prefs.ui:276
+#: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Trier le contenu du dossier"
 
-#: ui/prefs-gtk4.ui:206 ui/prefs.ui:327
+#: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr ""
 "Où placer les dossiers lors de l'organisation de la grille d'applications"
 
-#: ui/prefs-gtk4.ui:220 ui/prefs.ui:346
+#: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
 msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr "Position des dossiers ordonnés"
 
-#: ui/prefs-gtk4.ui:269 ui/prefs.ui:425
+#: ui/prefs-gtk4.ui:293 ui/prefs.ui:425
 msgid "Developer settings"
 msgstr "Paramètres du développeur"
 
-#: ui/prefs-gtk4.ui:287 ui/prefs.ui:461
+#: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
 msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr "Autoriser l'extension à envoyer des messages aux journaux système"
 
-#: ui/prefs-gtk4.ui:301 ui/prefs.ui:480
+#: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
 msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr "Activer la journalisation des extensions"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,4 +1,4 @@
-# <LANGUAGE> translation for the Alphabetical App Grid GNOME Shell Extension.
+# French translation for the Alphabetical App Grid GNOME Shell Extension.
 # Copyright (C) 2021 Stuart Hayhurst
 # This file is distributed under the same license as the alphabetical-grid-extension package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -7,149 +7,95 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-30 12:51+0200\n"
-"PO-Revision-Date: 2021-08-29 14:42+0200\n"
-"Last-Translator: Alan <Alan90000@yahoo.com>\n"
+"POT-Creation-Date: 2021-08-31 13:30+0200\n"
+"PO-Revision-Date: 2021-08-31 13:23+0200\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 3.0\n"
 
 #: extension.js:28
-#, fuzzy
-#| msgid "Reordering app grid"
-msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr "Réorganisation de la grille d'applications"
 
-#. Translators: The extension now uses its own method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to compare the items in the app grid.
 #: extension.js:82
-#, fuzzy
-#| msgid "Patched item comparison"
-msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr "Comparaison des éléments corrigés"
 
-#. Translators: The extension now uses its own method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to display the items in the app grid.
 #: extension.js:86
-#, fuzzy
-#| msgid "Patched redisplay"
-msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr "Réaffichage corrigé"
 
-#. Translators: The extension now uses the system method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to compare the items in the app grid.
 #: extension.js:93
-#, fuzzy
-#| msgid "Unpatched item comparison"
-msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr "Comparaison d'éléments non corrigés"
 
-#. Translators: The extension now uses the system method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to display the items in the app grid.
 #: extension.js:97
-#, fuzzy
-#| msgid "Unpatched redisplay"
-msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr "Réaffichage non corrigé"
 
 #: extension.js:110
-#, fuzzy
-#| msgid "Reordering folder contents"
-msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr "Réorganisation du contenu du dossier"
 
 #: extension.js:143
-#, fuzzy
-#| msgid "Favourite apps are already shown"
-msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr "Les applications préférées sont déjà affichées"
 
 #: extension.js:145
-#, fuzzy
-#| msgid "Favourite apps are already hidden"
-msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr "Les applications préférées sont déjà masquées"
 
 #: extension.js:150
-#, fuzzy
-#| msgid "Showing favourite apps on the app grid"
-msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr "Affichage des applications préférées sur la grille d'applications"
 
 #: extension.js:153
-#, fuzzy
-#| msgid "Hiding favourite apps on the app grid"
-msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr "Masquer les applications préférées sur la grille d'applications"
 
 #: extension.js:159
-#, fuzzy
-#| msgid "Reordering app grid, due to favourite apps"
-msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr ""
 "Réorganisation de la grille d'applications, en raison des applications "
 "préférées"
 
 #: extension.js:176
-#, fuzzy
-#| msgid "Connected to listeners"
-msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr "Connecté aux auditeurs"
 
 #: extension.js:190
-#, fuzzy
-#| msgid "Disconnected from listeners"
-msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr "Déconnecté des auditeurs"
 
 #: extension.js:205
-#, fuzzy
-#| msgid "App grid layout changed, triggering reorder"
-msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr ""
 "La disposition de la grille d'applications a été modifiée, déclenchant la "
 "réorganisation"
 
 #: extension.js:212
-#, fuzzy
-#| msgid "Favourite apps changed, triggering reorder"
-msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr "Applications préférées modifiées, déclenchant une réorganisation"
 
 #: extension.js:220
-#, fuzzy
-#| msgid "Extension gsettings values changed, triggering reorder"
-msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 "Les valeurs des paramètres d'extension ont changé, déclenchant la "
 "réorganisation"
 
 #: extension.js:227
-#, fuzzy
-#| msgid "Folders changed, triggering reorder"
-msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr "Les dossiers ont été modifiés, déclenchant la réorganisation"
 
 #: extension.js:234
-#, fuzzy
-#| msgid "Installed apps changed, triggering reorder"
-msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr ""
 "Les applications installées ont été modifiées, déclenchant une réorganisation"
@@ -185,21 +131,20 @@ msgstr "À propos de"
 msgid "Alphabetical App Grid Preferences"
 msgstr "Préférences de grille d'applications alphabétique"
 
-#. Folders will appear in alphabetical order, mixed with applications.
+#. When this is selected, folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
-msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr "Alphabétique"
 
-#. Folders will appear at the beginning of the app grid, in front of the other apps.
+#. When this is selected, folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
-msgctxt "folder-position"
+msgctxt "position"
 msgid "Start"
 msgstr "Démarrer"
 
-#. Folders will appear at the end of the app grid, behind the other apps.
+#. When this is selected, folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
-msgctxt "folder-position"
+msgctxt "position"
 msgid "End"
 msgstr "Fin"
 
@@ -217,16 +162,13 @@ msgstr ""
 msgid "GNOME 40+ settings"
 msgstr "Paramètres GNOME 40+"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
-#, fuzzy
-#| msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
 msgid "Allows displaying the favourite apps on the app grid"
 msgstr ""
-"Permet d'afficher les applications préférées sur la grille d'applications "
-"(GNOME 40+)"
+"Permet d'afficher les applications préférées sur la grille d'applications"
 
 #: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
-msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr "Afficher les applications préférées sur la grille d'applications"
 
@@ -234,23 +176,23 @@ msgstr "Afficher les applications préférées sur la grille d'applications"
 msgid "General settings"
 msgstr "Paramètres généraux"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
-msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr "Si le contenu des dossiers doit être trié par ordre alphabétique"
 
 #: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
-msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Trier le contenu du dossier"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr ""
 "Où placer les dossiers lors de l'organisation de la grille d'applications"
 
+#. Next to a dropdown with the options "Alphabetical", "Start" and "End".
 #: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
-msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr "Position des dossiers ordonnés"
 
@@ -258,12 +200,11 @@ msgstr "Position des dossiers ordonnés"
 msgid "Developer settings"
 msgstr "Paramètres du développeur"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
-msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr "Autoriser l'extension à envoyer des messages aux journaux système"
 
 #: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
-msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr "Activer la journalisation des extensions"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-26 19:52+0100\n"
+"POT-Creation-Date: 2021-08-30 12:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,74 +18,96 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: extension.js:28
+msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr ""
 
-#: extension.js:81
+#. Translators: The extension now uses its own method to compare the items in the app grid.
+#: extension.js:82
+msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr ""
 
-#: extension.js:84
+#. Translators: The extension now uses its own method to display the items in the app grid.
+#: extension.js:86
+msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr ""
 
-#: extension.js:90
+#. Translators: The extension now uses the system method to compare the items in the app grid.
+#: extension.js:93
+msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr ""
 
-#: extension.js:93
+#. Translators: The extension now uses the system method to display the items in the app grid.
+#: extension.js:97
+msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr ""
 
-#: extension.js:106
+#: extension.js:110
+msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr ""
 
-#: extension.js:139
+#: extension.js:143
+msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr ""
 
-#: extension.js:141
+#: extension.js:145
+msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr ""
 
-#: extension.js:146
+#: extension.js:150
+msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr ""
 
-#: extension.js:149
+#: extension.js:153
+msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr ""
 
-#: extension.js:155
+#: extension.js:159
+msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr ""
 
-#: extension.js:172
+#: extension.js:176
+msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr ""
 
-#: extension.js:186
+#: extension.js:190
+msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr ""
 
-#: extension.js:201
+#: extension.js:205
+msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr ""
 
-#: extension.js:208
+#: extension.js:212
+msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr ""
 
-#: extension.js:216
+#: extension.js:220
+msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 
-#: extension.js:223
+#: extension.js:227
+msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr ""
 
-#: extension.js:230
+#: extension.js:234
+msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr ""
 
@@ -120,74 +142,77 @@ msgstr ""
 msgid "Alphabetical App Grid Preferences"
 msgstr ""
 
+#. Folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
 msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr ""
 
+#. Folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
 msgctxt "folder-position"
 msgid "Start"
 msgstr ""
 
+#. Folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
 msgctxt "folder-position"
 msgid "End"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:41 ui/prefs.ui:53
+#: ui/prefs-gtk4.ui:45 ui/prefs.ui:53
 msgid ""
 "Found this useful?\n"
 "<a href=\"https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN"
 "\">Consider donating :)</a>"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:68 ui/prefs.ui:93
+#: ui/prefs-gtk4.ui:76 ui/prefs.ui:93
 msgid "GNOME 40+ settings"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:86 ui/prefs.ui:129
-msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
+#: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
+msgid "Allows displaying the favourite apps on the app grid"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:100 ui/prefs.ui:148
+#: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
 msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:144 ui/prefs.ui:221
+#: ui/prefs-gtk4.ui:158 ui/prefs.ui:221
 msgid "General settings"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:162 ui/prefs.ui:257
+#: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:176 ui/prefs.ui:276
+#: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:206 ui/prefs.ui:327
+#: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:220 ui/prefs.ui:346
+#: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
 msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:269 ui/prefs.ui:425
+#: ui/prefs-gtk4.ui:293 ui/prefs.ui:425
 msgid "Developer settings"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:287 ui/prefs.ui:461
+#: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
 msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr ""
 
-#: ui/prefs-gtk4.ui:301 ui/prefs.ui:480
+#: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
 msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr ""

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-30 12:57+0200\n"
+"POT-Creation-Date: 2021-08-31 13:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,96 +18,78 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: extension.js:28
-msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr ""
 
-#. Translators: The extension now uses its own method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to compare the items in the app grid.
 #: extension.js:82
-msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr ""
 
-#. Translators: The extension now uses its own method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to display the items in the app grid.
 #: extension.js:86
-msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr ""
 
-#. Translators: The extension now uses the system method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to compare the items in the app grid.
 #: extension.js:93
-msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr ""
 
-#. Translators: The extension now uses the system method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to display the items in the app grid.
 #: extension.js:97
-msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr ""
 
 #: extension.js:110
-msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr ""
 
 #: extension.js:143
-msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr ""
 
 #: extension.js:145
-msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr ""
 
 #: extension.js:150
-msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr ""
 
 #: extension.js:153
-msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr ""
 
 #: extension.js:159
-msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr ""
 
 #: extension.js:176
-msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr ""
 
 #: extension.js:190
-msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr ""
 
 #: extension.js:205
-msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr ""
 
 #: extension.js:212
-msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr ""
 
 #: extension.js:220
-msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 
 #: extension.js:227
-msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr ""
 
 #: extension.js:234
-msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr ""
 
@@ -142,21 +124,20 @@ msgstr ""
 msgid "Alphabetical App Grid Preferences"
 msgstr ""
 
-#. Folders will appear in alphabetical order, mixed with applications.
+#. When this is selected, folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
-msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr ""
 
-#. Folders will appear at the beginning of the app grid, in front of the other apps.
+#. When this is selected, folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
-msgctxt "folder-position"
+msgctxt "position"
 msgid "Start"
 msgstr ""
 
-#. Folders will appear at the end of the app grid, behind the other apps.
+#. When this is selected, folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
-msgctxt "folder-position"
+msgctxt "position"
 msgid "End"
 msgstr ""
 
@@ -171,12 +152,12 @@ msgstr ""
 msgid "GNOME 40+ settings"
 msgstr ""
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
 msgid "Allows displaying the favourite apps on the app grid"
 msgstr ""
 
 #: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
-msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr ""
 
@@ -184,22 +165,22 @@ msgstr ""
 msgid "General settings"
 msgstr ""
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
-msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr ""
 
 #: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
-msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr ""
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr ""
 
+#. Next to a dropdown with the options "Alphabetical", "Start" and "End".
 #: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
-msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr ""
 
@@ -207,12 +188,11 @@ msgstr ""
 msgid "Developer settings"
 msgstr ""
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
-msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr ""
 
 #: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
-msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,4 +1,4 @@
-# <LANGUAGE> translation for the Alphabetical App Grid GNOME Shell Extension.
+# Dutch translation for the Alphabetical App Grid GNOME Shell Extension.
 # Copyright (C) 2021 Stuart Hayhurst
 # This file is distributed under the same license as the alphabetical-grid-extension package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-30 12:51+0200\n"
-"PO-Revision-Date: 2021-08-27 14:29+0200\n"
-"Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
+"POT-Creation-Date: 2021-08-31 13:30+0200\n"
+"PO-Revision-Date: 2021-08-31 13:26+0200\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: \n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -19,133 +19,79 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: extension.js:28
-#, fuzzy
-#| msgid "Reordering app grid"
-msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr "Bezig met herordenen…"
 
-#. Translators: The extension now uses its own method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to compare the items in the app grid.
 #: extension.js:82
-#, fuzzy
-#| msgid "Patched item comparison"
-msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr "Verschil tussen gepatchte items"
 
-#. Translators: The extension now uses its own method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses its own method to display the items in the app grid.
 #: extension.js:86
-#, fuzzy
-#| msgid "Patched redisplay"
-msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr "Patches toepassen op toepassingsoverzicht"
 
-#. Translators: The extension now uses the system method to compare the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to compare the items in the app grid.
 #: extension.js:93
-#, fuzzy
-#| msgid "Unpatched item comparison"
-msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr "Verschil tussen ongepatchte items"
 
-#. Translators: The extension now uses the system method to display the items in the app grid.
+#. Translators: This is a log message. The extension now uses the system method to display the items in the app grid.
 #: extension.js:97
-#, fuzzy
-#| msgid "Unpatched redisplay"
-msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr "Ongepatchte items toepassen op toepassingsoverzicht"
 
 #: extension.js:110
-#, fuzzy
-#| msgid "Reordering folder contents"
-msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr "Bezig met herordenen…"
 
 #: extension.js:143
-#, fuzzy
-#| msgid "Favourite apps are already shown"
-msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr "Uw favoriete toepassingen worden al getoond"
 
 #: extension.js:145
-#, fuzzy
-#| msgid "Favourite apps are already hidden"
-msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr "Uw favoriete toepassingen zijn al verborgen"
 
 #: extension.js:150
-#, fuzzy
-#| msgid "Showing favourite apps on the app grid"
-msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr "Uw favoriete toepassingen worden getoond op het rooster"
 
 #: extension.js:153
-#, fuzzy
-#| msgid "Hiding favourite apps on the app grid"
-msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr "Uw favoriete toepassingen zijn verborgen van het rooster"
 
 #: extension.js:159
-#, fuzzy
-#| msgid "Reordering app grid, due to favourite apps"
-msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr "De favoriete toepassingen worden toegevoegd - bezig met herordenen…"
 
 #: extension.js:176
-#, fuzzy
-#| msgid "Connected to listeners"
-msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr "Verbonden met achtergronddienst"
 
 #: extension.js:190
-#, fuzzy
-#| msgid "Disconnected from listeners"
-msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr "Verbinding verbroken met achtergronddienst"
 
 #: extension.js:205
-#, fuzzy
-#| msgid "App grid layout changed, triggering reorder"
-msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr "De toepassingsindeling is gewijzigd - bezig met herordenen…"
 
 #: extension.js:212
-#, fuzzy
-#| msgid "Favourite apps changed, triggering reorder"
-msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr "De favoriete toepassingen zijn gewijzigd - bezig met herordenen…"
 
 #: extension.js:220
-#, fuzzy
-#| msgid "Extension gsettings values changed, triggering reorder"
-msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 "De uitbreidingswaarden (gsettings) zijn aangepast - bezig met herordenen…"
 
 #: extension.js:227
-#, fuzzy
-#| msgid "Folders changed, triggering reorder"
-msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr "De mappen zijn gewijzigd - bezig met herordenen…"
 
 #: extension.js:234
-#, fuzzy
-#| msgid "Installed apps changed, triggering reorder"
-msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr "De geïnstalleerde toepassingen zijn gewijzigd - bezig met herordenen…"
 
@@ -180,21 +126,26 @@ msgstr "Over"
 msgid "Alphabetical App Grid Preferences"
 msgstr "Voorkeuren"
 
-#. Folders will appear in alphabetical order, mixed with applications.
+#. When this is selected, folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
-msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr "Alfabetisch"
 
-#. Folders will appear at the beginning of the app grid, in front of the other apps.
+#. When this is selected, folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
-msgctxt "folder-position"
+#, fuzzy
+#| msgctxt "folder-position"
+#| msgid "Start"
+msgctxt "position"
 msgid "Start"
 msgstr "Begin"
 
-#. Folders will appear at the end of the app grid, behind the other apps.
+#. When this is selected, folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
-msgctxt "folder-position"
+#, fuzzy
+#| msgctxt "folder-position"
+#| msgid "End"
+msgctxt "position"
 msgid "End"
 msgstr "Einde"
 
@@ -212,16 +163,12 @@ msgstr ""
 msgid "GNOME 40+ settings"
 msgstr "GNOME 40+-voorkeuren"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
-#, fuzzy
-#| msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
 msgid "Allows displaying the favourite apps on the app grid"
-msgstr ""
-"Toont uw favoriete toepassingen op het toepassingsrooster (GNOME 40 en "
-"nieuwer)"
+msgstr "Toont uw favoriete toepassingen op het toepassingsrooster"
 
 #: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
-msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr "Favoriete toepassingen tonen op rooster"
 
@@ -229,22 +176,22 @@ msgstr "Favoriete toepassingen tonen op rooster"
 msgid "General settings"
 msgstr "Algemene voorkeuren"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
-msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr "Of mapinhoud alfabetisch gesorteerd moet worden"
 
 #: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
-msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Mapinhoud sorteren"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr "Waar mappen geplaatst moeten worden op het rooster"
 
+#. Next to a dropdown with the options "Alphabetical", "Start" and "End".
 #: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
-msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr "Positie van geordende mappen"
 
@@ -252,12 +199,11 @@ msgstr "Positie van geordende mappen"
 msgid "Developer settings"
 msgstr "Ontwikkelaarsvoorkeuren"
 
+#. This is a tooltip.
 #: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
-msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr "Laat de extensie een logboek aanleggen met daarin alle uitvoer"
 
 #: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
-msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr "Logboek aanleggen"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-26 19:52+0100\n"
+"POT-Creation-Date: 2021-08-30 12:51+0200\n"
 "PO-Revision-Date: 2021-08-27 14:29+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -19,75 +19,133 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: extension.js:28
+#, fuzzy
+#| msgid "Reordering app grid"
+msgctxt "log-message"
 msgid "Reordering app grid"
 msgstr "Bezig met herordenen…"
 
-#: extension.js:81
+#. Translators: The extension now uses its own method to compare the items in the app grid.
+#: extension.js:82
+#, fuzzy
+#| msgid "Patched item comparison"
+msgctxt "log-message"
 msgid "Patched item comparison"
 msgstr "Verschil tussen gepatchte items"
 
-#: extension.js:84
+#. Translators: The extension now uses its own method to display the items in the app grid.
+#: extension.js:86
+#, fuzzy
+#| msgid "Patched redisplay"
+msgctxt "log-message"
 msgid "Patched redisplay"
 msgstr "Patches toepassen op toepassingsoverzicht"
 
-#: extension.js:90
+#. Translators: The extension now uses the system method to compare the items in the app grid.
+#: extension.js:93
+#, fuzzy
+#| msgid "Unpatched item comparison"
+msgctxt "log-message"
 msgid "Unpatched item comparison"
 msgstr "Verschil tussen ongepatchte items"
 
-#: extension.js:93
+#. Translators: The extension now uses the system method to display the items in the app grid.
+#: extension.js:97
+#, fuzzy
+#| msgid "Unpatched redisplay"
+msgctxt "log-message"
 msgid "Unpatched redisplay"
 msgstr "Ongepatchte items toepassen op toepassingsoverzicht"
 
-#: extension.js:106
+#: extension.js:110
+#, fuzzy
+#| msgid "Reordering folder contents"
+msgctxt "log-message"
 msgid "Reordering folder contents"
 msgstr "Bezig met herordenen…"
 
-#: extension.js:139
+#: extension.js:143
+#, fuzzy
+#| msgid "Favourite apps are already shown"
+msgctxt "log-message"
 msgid "Favourite apps are already shown"
 msgstr "Uw favoriete toepassingen worden al getoond"
 
-#: extension.js:141
+#: extension.js:145
+#, fuzzy
+#| msgid "Favourite apps are already hidden"
+msgctxt "log-message"
 msgid "Favourite apps are already hidden"
 msgstr "Uw favoriete toepassingen zijn al verborgen"
 
-#: extension.js:146
+#: extension.js:150
+#, fuzzy
+#| msgid "Showing favourite apps on the app grid"
+msgctxt "log-message"
 msgid "Showing favourite apps on the app grid"
 msgstr "Uw favoriete toepassingen worden getoond op het rooster"
 
-#: extension.js:149
+#: extension.js:153
+#, fuzzy
+#| msgid "Hiding favourite apps on the app grid"
+msgctxt "log-message"
 msgid "Hiding favourite apps on the app grid"
 msgstr "Uw favoriete toepassingen zijn verborgen van het rooster"
 
-#: extension.js:155
+#: extension.js:159
+#, fuzzy
+#| msgid "Reordering app grid, due to favourite apps"
+msgctxt "log-message"
 msgid "Reordering app grid, due to favourite apps"
 msgstr "De favoriete toepassingen worden toegevoegd - bezig met herordenen…"
 
-#: extension.js:172
+#: extension.js:176
+#, fuzzy
+#| msgid "Connected to listeners"
+msgctxt "log-message"
 msgid "Connected to listeners"
 msgstr "Verbonden met achtergronddienst"
 
-#: extension.js:186
+#: extension.js:190
+#, fuzzy
+#| msgid "Disconnected from listeners"
+msgctxt "log-message"
 msgid "Disconnected from listeners"
 msgstr "Verbinding verbroken met achtergronddienst"
 
-#: extension.js:201
+#: extension.js:205
+#, fuzzy
+#| msgid "App grid layout changed, triggering reorder"
+msgctxt "log-message"
 msgid "App grid layout changed, triggering reorder"
 msgstr "De toepassingsindeling is gewijzigd - bezig met herordenen…"
 
-#: extension.js:208
+#: extension.js:212
+#, fuzzy
+#| msgid "Favourite apps changed, triggering reorder"
+msgctxt "log-message"
 msgid "Favourite apps changed, triggering reorder"
 msgstr "De favoriete toepassingen zijn gewijzigd - bezig met herordenen…"
 
-#: extension.js:216
+#: extension.js:220
+#, fuzzy
+#| msgid "Extension gsettings values changed, triggering reorder"
+msgctxt "log-message"
 msgid "Extension gsettings values changed, triggering reorder"
 msgstr ""
 "De uitbreidingswaarden (gsettings) zijn aangepast - bezig met herordenen…"
 
-#: extension.js:223
+#: extension.js:227
+#, fuzzy
+#| msgid "Folders changed, triggering reorder"
+msgctxt "log-message"
 msgid "Folders changed, triggering reorder"
 msgstr "De mappen zijn gewijzigd - bezig met herordenen…"
 
-#: extension.js:230
+#: extension.js:234
+#, fuzzy
+#| msgid "Installed apps changed, triggering reorder"
+msgctxt "log-message"
 msgid "Installed apps changed, triggering reorder"
 msgstr "De geïnstalleerde toepassingen zijn gewijzigd - bezig met herordenen…"
 
@@ -122,22 +180,25 @@ msgstr "Over"
 msgid "Alphabetical App Grid Preferences"
 msgstr "Voorkeuren"
 
+#. Folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
 msgctxt "folder-position"
 msgid "Alphabetical"
 msgstr "Alfabetisch"
 
+#. Folders will appear at the beginning of the app grid, in front of the other apps.
 #: ui/prefs-gtk4.ui:15 ui/prefs.ui:18
 msgctxt "folder-position"
 msgid "Start"
 msgstr "Begin"
 
+#. Folders will appear at the end of the app grid, behind the other apps.
 #: ui/prefs-gtk4.ui:19 ui/prefs.ui:22
 msgctxt "folder-position"
 msgid "End"
 msgstr "Einde"
 
-#: ui/prefs-gtk4.ui:41 ui/prefs.ui:53
+#: ui/prefs-gtk4.ui:45 ui/prefs.ui:53
 msgid ""
 "Found this useful?\n"
 "<a href=\"https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN"
@@ -147,54 +208,56 @@ msgstr ""
 "<a href=\"https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN"
 "\">Overweeg dan een donatie :)</a>"
 
-#: ui/prefs-gtk4.ui:68 ui/prefs.ui:93
+#: ui/prefs-gtk4.ui:76 ui/prefs.ui:93
 msgid "GNOME 40+ settings"
 msgstr "GNOME 40+-voorkeuren"
 
-#: ui/prefs-gtk4.ui:86 ui/prefs.ui:129
-msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
+#: ui/prefs-gtk4.ui:94 ui/prefs.ui:129
+#, fuzzy
+#| msgid "Allows displaying the favourite apps on the app grid (GNOME 40+)"
+msgid "Allows displaying the favourite apps on the app grid"
 msgstr ""
 "Toont uw favoriete toepassingen op het toepassingsrooster (GNOME 40 en "
 "nieuwer)"
 
-#: ui/prefs-gtk4.ui:100 ui/prefs.ui:148
+#: ui/prefs-gtk4.ui:111 ui/prefs.ui:148
 msgctxt "setting-name"
 msgid "Show favourite apps on the app grid"
 msgstr "Favoriete toepassingen tonen op rooster"
 
-#: ui/prefs-gtk4.ui:144 ui/prefs.ui:221
+#: ui/prefs-gtk4.ui:158 ui/prefs.ui:221
 msgid "General settings"
 msgstr "Algemene voorkeuren"
 
-#: ui/prefs-gtk4.ui:162 ui/prefs.ui:257
+#: ui/prefs-gtk4.ui:176 ui/prefs.ui:257
 msgctxt "setting-tooltip"
 msgid "Whether the contents of folders should be sorted alphabetically"
 msgstr "Of mapinhoud alfabetisch gesorteerd moet worden"
 
-#: ui/prefs-gtk4.ui:176 ui/prefs.ui:276
+#: ui/prefs-gtk4.ui:193 ui/prefs.ui:276
 msgctxt "setting-name"
 msgid "Sort folder contents"
 msgstr "Mapinhoud sorteren"
 
-#: ui/prefs-gtk4.ui:206 ui/prefs.ui:327
+#: ui/prefs-gtk4.ui:222 ui/prefs.ui:327
 msgid "Where to place folders when ordering the applications grid"
 msgstr "Waar mappen geplaatst moeten worden op het rooster"
 
-#: ui/prefs-gtk4.ui:220 ui/prefs.ui:346
+#: ui/prefs-gtk4.ui:239 ui/prefs.ui:346
 msgctxt "setting-name"
 msgid "Position of ordered folders"
 msgstr "Positie van geordende mappen"
 
-#: ui/prefs-gtk4.ui:269 ui/prefs.ui:425
+#: ui/prefs-gtk4.ui:293 ui/prefs.ui:425
 msgid "Developer settings"
 msgstr "Ontwikkelaarsvoorkeuren"
 
-#: ui/prefs-gtk4.ui:287 ui/prefs.ui:461
+#: ui/prefs-gtk4.ui:311 ui/prefs.ui:461
 msgctxt "setting-tooltip"
 msgid "Allow the extension to send messages to the system logs"
 msgstr "Laat de extensie een logboek aanleggen met daarin alle uitvoer"
 
-#: ui/prefs-gtk4.ui:301 ui/prefs.ui:480
+#: ui/prefs-gtk4.ui:328 ui/prefs.ui:480
 msgctxt "setting-name"
 msgid "Enable extension logging"
 msgstr "Logboek aanleggen"

--- a/scripts/update-pot.sh
+++ b/scripts/update-pot.sh
@@ -17,7 +17,8 @@ cd "$( cd "$( dirname "$0" )" && pwd )/.." || \
 
 #Update the template file with the strings from the source tree
 echo "Generating 'messages.pot'..."
-xgettext --from-code=UTF-8 \
+xgettext --keyword=C_:1c,2 \
+         --from-code=UTF-8 \
          --add-comments=Translators \
          --copyright-holder="Stuart Hayhurst" \
          --package-name="alphabetical-grid-extension" \

--- a/scripts/update-pot.sh
+++ b/scripts/update-pot.sh
@@ -17,8 +17,7 @@ cd "$( cd "$( dirname "$0" )" && pwd )/.." || \
 
 #Update the template file with the strings from the source tree
 echo "Generating 'messages.pot'..."
-xgettext --keyword=C_:1c,2 \
-         --from-code=UTF-8 \
+xgettext --from-code=UTF-8 \
          --add-comments=Translators \
          --copyright-holder="Stuart Hayhurst" \
          --package-name="alphabetical-grid-extension" \

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -8,36 +8,40 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes" context="folder-position">Alphabetical</col>
+        <col id="0" translatable="yes" comments="When this is selected, folders will appear in alphabetical order, mixed with applications.">Alphabetical</col>
         <col id="1">alphabetical</col>
       </row>
       <row>
-        <col id="0" translatable="yes" context="folder-position">Start</col>
+        <col id="0" translatable="yes" context="position" comments="When this is selected, folders will appear at the beginning of the app grid, in front of the other apps.">Start</col>
         <col id="1">start</col>
       </row>
       <row>
-        <col id="0" translatable="yes" context="folder-position">End</col>
+        <col id="0" translatable="yes" context="position" comments="When this is selected, folders will appear at the end of the app grid, behind the other apps.">End</col>
         <col id="1">end</col>
       </row>
     </data>
   </object>
   <object class="GtkBox" id="main-prefs">
+    <property name="can-focus">0</property>
     <property name="margin-top">12</property>
     <property name="margin-bottom">10</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkGrid">
+        <property name="can-focus">0</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
         <property name="column-homogeneous">1</property>
         <child>
           <object class="GtkBox" id="donate-box">
+            <property name="can-focus">0</property>
             <property name="valign">end</property>
             <property name="margin-top">4</property>
             <property name="vexpand">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="donate-prompt">
+                <property name="can-focus">0</property>
                 <property name="label" translatable="yes">Found this useful?
 &lt;a href=&quot;https://www.paypal.com/donate?hosted_button_id=G2REEPPNZK9GN&quot;&gt;Consider donating :)&lt;/a&gt;</property>
                 <property name="use-markup">1</property>
@@ -52,19 +56,23 @@
         </child>
         <child>
           <object class="GtkBox" id="gnome40-box">
+            <property name="can-focus">0</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
+                <property name="can-focus">0</property>
                 <property name="margin-top">12</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <property name="can-focus">0</property>
                     <property name="margin-start">2</property>
                     <property name="margin-top">4</property>
                     <property name="margin-bottom">6</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel" id="gnome40-settings-title">
+                        <property name="can-focus">0</property>
                         <property name="label" translatable="yes">GNOME 40+ settings</property>
                         <property name="xalign">0</property>
                         <attributes>
@@ -79,31 +87,33 @@
             </child>
             <child>
               <object class="GtkListBox" id="gnome40-settings">
+                <property name="can-focus">0</property>
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
-                    <property name="tooltip-text" translatable="yes">Allows displaying the favourite apps on the app grid (GNOME 40+)</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Allows displaying the favourite apps on the app grid</property>
                     <property name="child">
                       <object class="GtkBox">
+                        <property name="can-focus">0</property>
                         <property name="margin-top">12</property>
                         <property name="margin-bottom">12</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <property name="can-focus">0</property>
                             <property name="spacing">32</property>
                             <child>
                               <object class="GtkLabel">
                                 <property name="hexpand">1</property>
+                                <property name="can-focus">0</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Show favourite apps on the app grid</property>
+                                <property name="label" translatable="yes">Show favourite apps on the app grid</property>
                                 <property name="xalign">0</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkSwitch" id="show-favourite-apps-switch">
-                                <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="margin-end">10</property>
                                 <property name="active">1</property>
@@ -128,19 +138,23 @@
         </child>
         <child>
           <object class="GtkBox" id="general-box">
+            <property name="can-focus">0</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
+                <property name="can-focus">0</property>
                 <property name="margin-top">12</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <property name="can-focus">0</property>
                     <property name="margin-start">2</property>
                     <property name="margin-top">4</property>
                     <property name="margin-bottom">6</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel" id="settings-title">
+                        <property name="can-focus">0</property>
                         <property name="label" translatable="yes">General settings</property>
                         <property name="xalign">0</property>
                         <attributes>
@@ -155,31 +169,33 @@
             </child>
             <child>
               <object class="GtkListBox" id="general-settings">
+                <property name="can-focus">0</property>
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
-                    <property name="tooltip-text" translatable="yes" context="setting-tooltip">Whether the contents of folders should be sorted alphabetically</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Whether the contents of folders should be sorted alphabetically</property>
                     <property name="child">
                       <object class="GtkBox">
+                        <property name="can-focus">0</property>
                         <property name="margin-top">12</property>
                         <property name="margin-bottom">12</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <property name="can-focus">0</property>
                             <property name="spacing">32</property>
                             <child>
                               <object class="GtkLabel">
                                 <property name="hexpand">1</property>
+                                <property name="can-focus">0</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Sort folder contents</property>
+                                <property name="label" translatable="yes">Sort folder contents</property>
                                 <property name="xalign">0</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkSwitch" id="sort-folders-switch">
-                                <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="margin-end">10</property>
                                 <property name="active">1</property>
@@ -194,35 +210,39 @@
                 <child>
                   <object class="GtkListBoxRow">
                     <property name="sensitive">0</property>
-                    <property name="focusable">1</property>
                     <property name="child">
-                      <object class="GtkSeparator"/>
+                      <object class="GtkSeparator">
+                        <property name="can-focus">0</property>
+                      </object>
                     </property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
-                    <property name="tooltip-text" translatable="yes">Where to place folders when ordering the applications grid</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Where to place folders when ordering the applications grid</property>
                     <property name="child">
                       <object class="GtkBox">
+                        <property name="can-focus">0</property>
                         <property name="margin-top">12</property>
                         <property name="margin-bottom">12</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <property name="can-focus">0</property>
                             <property name="spacing">32</property>
                             <child>
                               <object class="GtkLabel">
                                 <property name="hexpand">1</property>
+                                <property name="can-focus">0</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Position of ordered folders</property>
+                                <property name="label" translatable="yes" comments="Next to a dropdown with the options &quot;Alphabetical&quot;, &quot;Start&quot; and &quot;End&quot;.">Position of ordered folders</property>
                                 <property name="xalign">0</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="folder-order-dropdown">
+                                <property name="can-focus">0</property>
                                 <property name="margin-end">10</property>
                                 <property name="model">folder-positions</property>
                                 <property name="id-column">1</property>
@@ -253,19 +273,23 @@
         </child>
         <child>
           <object class="GtkBox" id="dev-box">
+            <property name="can-focus">0</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
+                <property name="can-focus">0</property>
                 <property name="margin-top">12</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <property name="can-focus">0</property>
                     <property name="margin-start">2</property>
                     <property name="margin-top">4</property>
                     <property name="margin-bottom">6</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel" id="dev-settings-title">
+                        <property name="can-focus">0</property>
                         <property name="label" translatable="yes">Developer settings</property>
                         <property name="xalign">0</property>
                         <attributes>
@@ -280,31 +304,33 @@
             </child>
             <child>
               <object class="GtkListBox" id="dev-settings">
+                <property name="can-focus">0</property>
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
-                    <property name="tooltip-text" translatable="yes" context="setting-tooltip">Allow the extension to send messages to the system logs</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Allow the extension to send messages to the system logs</property>
                     <property name="child">
                       <object class="GtkBox">
+                        <property name="can-focus">0</property>
                         <property name="margin-top">12</property>
                         <property name="margin-bottom">12</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <property name="can-focus">0</property>
                             <property name="spacing">32</property>
                             <child>
                               <object class="GtkLabel">
                                 <property name="hexpand">1</property>
+                                <property name="can-focus">0</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Enable extension logging</property>
+                                <property name="label" translatable="yes">Enable extension logging</property>
                                 <property name="xalign">0</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkSwitch" id="logging-enabled-switch">
-                                <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="margin-end">10</property>
                                 <property name="active">1</property>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -126,7 +126,7 @@
                   <object class="GtkListBoxRow">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="tooltip-text" translatable="yes">Allows displaying the favourite apps on the app grid (GNOME 40+)</property>
+                    <property name="tooltip-text" translatable="yes">Allows displaying the favourite apps on the app grid</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -11,15 +11,15 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes" context="folder-position">Alphabetical</col>
+        <col id="0" translatable="yes" context="folder-position" comments="Folders will appear in alphabetical order, mixed with applications.">Alphabetical</col>
         <col id="1">alphabetical</col>
       </row>
       <row>
-        <col id="0" translatable="yes" context="folder-position">Start</col>
+        <col id="0" translatable="yes" context="folder-position" comments="Folders will appear at the beginning of the app grid, in front of the other apps.">Start</col>
         <col id="1">start</col>
       </row>
       <row>
-        <col id="0" translatable="yes" context="folder-position">End</col>
+        <col id="0" translatable="yes" context="folder-position" comments="Folders will appear at the end of the app grid, behind the other apps.">End</col>
         <col id="1">end</col>
       </row>
     </data>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -11,15 +11,15 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes" context="folder-position" comments="Folders will appear in alphabetical order, mixed with applications.">Alphabetical</col>
+        <col id="0" translatable="yes" comments="When this is selected, folders will appear in alphabetical order, mixed with applications.">Alphabetical</col>
         <col id="1">alphabetical</col>
       </row>
       <row>
-        <col id="0" translatable="yes" context="folder-position" comments="Folders will appear at the beginning of the app grid, in front of the other apps.">Start</col>
+        <col id="0" translatable="yes" context="position" comments="When this is selected, folders will appear at the beginning of the app grid, in front of the other apps.">Start</col>
         <col id="1">start</col>
       </row>
       <row>
-        <col id="0" translatable="yes" context="folder-position" comments="Folders will appear at the end of the app grid, behind the other apps.">End</col>
+        <col id="0" translatable="yes" context="position" comments="When this is selected, folders will appear at the end of the app grid, behind the other apps.">End</col>
         <col id="1">end</col>
       </row>
     </data>
@@ -126,7 +126,7 @@
                   <object class="GtkListBoxRow">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="tooltip-text" translatable="yes">Allows displaying the favourite apps on the app grid</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Allows displaying the favourite apps on the app grid</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -145,7 +145,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Show favourite apps on the app grid</property>
+                                <property name="label" translatable="yes">Show favourite apps on the app grid</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
@@ -254,7 +254,7 @@
                   <object class="GtkListBoxRow">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="tooltip-text" translatable="yes" context="setting-tooltip">Whether the contents of folders should be sorted alphabetically</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Whether the contents of folders should be sorted alphabetically</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -273,7 +273,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Sort folder contents</property>
+                                <property name="label" translatable="yes">Sort folder contents</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
@@ -324,7 +324,7 @@
                   <object class="GtkListBoxRow">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="tooltip-text" translatable="yes">Where to place folders when ordering the applications grid</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Where to place folders when ordering the applications grid</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -343,7 +343,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Position of ordered folders</property>
+                                <property name="label" translatable="yes" comments="Next to a dropdown with the options &quot;Alphabetical&quot;, &quot;Start&quot; and &quot;End&quot;.">Position of ordered folders</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
@@ -458,7 +458,7 @@
                   <object class="GtkListBoxRow">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="tooltip-text" translatable="yes" context="setting-tooltip">Allow the extension to send messages to the system logs</property>
+                    <property name="tooltip-text" translatable="yes" comments="This is a tooltip.">Allow the extension to send messages to the system logs</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -477,7 +477,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes" context="setting-name">Enable extension logging</property>
+                                <property name="label" translatable="yes">Enable extension logging</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>


### PR DESCRIPTION
## Pull request summary:

As mentioned in #32, I had a look at the strings and added some `msgctxt`s here and there - as well as other small string-related improvements.
I changed the way we import the translation related stuff. I couldn't get it to work otherwise, but I have very little experience in this sort of stuff - so please have a look and see if you can find another/better solution, if desired. :see_no_evil:

My sources:
- https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/core/_gettext.js#L55
- https://wiki.gnome.org/Projects/GnomeShell/Extensions/FAQ/CreatingExtensions

## UI related changes:

I removed the info about GNOME 40+ in the tooltip of the "Display favourite apps on the app grid" setting, since the fact that this is GNOME 40+ only is already communicated via the section heading.

## Still to do:

I somehow failed to abbreviate `Gettext.pgettext`, like `Gettext.gettext` is abbreviated to `_`. I tried

```javascript
const _c = Gettext.pgettext;
```

but then it wouldn't recognize any strings marked `_c('like this')` (i. e. not include them in the `pot` and `po` files). Do you have an idea why this is the case and how to fix it?
Feel free to commit a fix to my branch before merging this PR, I've allowed pushes by maintainers of this repo :)