### PR TITLE
Use apt-get instead of apt (stable cli interface)

### DIFF
--- a/.github/workflows/test-build-system.yml
+++ b/.github/workflows/test-build-system.yml
@@ -18,8 +18,8 @@ jobs:
         python-version: 3.9
     - name: Install build dependencies
       run: |
-        sudo apt update
-        sudo apt install --no-install-recommends git make optipng gettext gnome-shell libglib2.0-bin
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends git make optipng gettext gnome-shell libglib2.0-bin
     - name: Check assets are optimised and no extra files have been committed
       run: |
         # Check all assets are space optimised


### PR DESCRIPTION
## Pull request summary:
This PR exchanges `apt` with `apt-get` in the CI test files, because `apt` has no stable CLI interface. This means that it does not just throw messages out to stdout and forgets about them - it comes back and edits lines (to display a progress bar, for example).

While this is a cool feature in direct interaction with the user, it is not ideal when using `apt` in a script, where the output gets written to a text file (or GitHubs log viewer).

`apt-get` does provide a stable CLI interface.