### PR TITLE
Add functionality for variables passed to `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL=bash
 UUID=AlphabeticalAppGrid@stuarthayhurst
 
+COMPRESSLEVEL="-o7"
+
 .PHONY: build package check release translations gtk4 prune compress install uninstall clean
 
 build:
@@ -31,7 +33,7 @@ gtk4:
 prune:
 	./scripts/clean-svgs.py
 compress:
-	optipng -o7 -strip all docs/*.png
+	optipng $(COMPRESSLEVEL) -strip all docs/*.png
 install:
 	gnome-extensions install "$(UUID).shell-extension.zip" --force
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ check:
 	  echo -e "\nWARNING! Debug mode is enabled, a release shouldn't be published"; exit 1; \
 	fi
 release:
+	if [[ "$(VERSION)" != "" ]]; then \
+	  sed -i "s|  \"version\":.*|  \"version\": $(VERSION),|g" metadata.json; \
+	fi
+	#Call other targets required to make a release
 	$(MAKE) gtk4
 	$(MAKE) translations
 	$(MAKE) prune

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 SHELL=bash
 UUID=AlphabeticalAppGrid@stuarthayhurst
-
 COMPRESSLEVEL="-o7"
 
 .PHONY: build package check release translations gtk4 prune compress install uninstall clean
@@ -37,7 +36,7 @@ gtk4:
 prune:
 	./scripts/clean-svgs.py
 compress:
-	optipng $(COMPRESSLEVEL) -strip all docs/*.png
+	optipng "$(COMPRESSLEVEL)" -strip all docs/*.png
 install:
 	gnome-extensions install "$(UUID).shell-extension.zip" --force
 uninstall:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@
     - `make translations`: Updates translations
     - `make prune`: Removes rubbish from any .svgs in `docs/`
     - `make compress`: Losslessly compresses any .pngs in `docs/`
+      - Allows passing `COMPRESSLEVEL="-oX"`, where x is an integer between 0-7
     - `make release`: Updates the GTK 4 UI, translations, then creates and checks an extension zip
+      - Calls `make gtk4 translations prune compress build check`
+      - Supports any variables / arguments supported by these targets
     - `make package`: Creates the extension zip from the project's current state (Only useful for debugging)
 
 ## Install dependencies:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
     - `make release`: Updates the GTK 4 UI, translations, then creates and checks an extension zip
       - Calls `make gtk4 translations prune compress build check`
       - Supports any variables / arguments supported by these targets
+      - Also allows passing `VERSION="XX"`, where XX is the version to update `metadata.json` to
     - `make package`: Creates the extension zip from the project's current state (Only useful for debugging)
 
 ## Install dependencies:


### PR DESCRIPTION
## Pull request summary:
 - Implement uses for a few variables passed to `make` targets

## Build system related changes:
 - `COMPRESSLEVEL="-oX"` is now supported (where X is a supported compression level), and documented
 - `VERSION="XX"` is supported for `make release`, where XX is the version to update `metadata.json` to

## Related issues / pull requests:
 - Handles the bottom 2 tasks in #40

Left open, in case @daPhipz has any suggestions :)