### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL=bash
 UUID=AlphabeticalAppGrid@stuarthayhurst
+
+PNG_FILES="docs/icon.png"
 COMPRESSLEVEL="-o7"
 
 .PHONY: build package check release translations gtk4 prune compress install uninstall clean
@@ -35,8 +37,8 @@ gtk4:
 	gtk4-builder-tool simplify --3to4 ui/prefs.ui > ui/prefs-gtk4.ui
 prune:
 	./scripts/clean-svgs.py
-compress:
-	optipng "$(COMPRESSLEVEL)" -strip all docs/*.png
+compress: $(PNG_FILES)
+	optipng "$(COMPRESSLEVEL)" -strip all $(PNG_FILES)
 install:
 	gnome-extensions install "$(UUID).shell-extension.zip" --force
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 package:
 	gnome-extensions pack --force --podir=po --extra-source=LICENSE.txt --extra-source=docs/CHANGELOG.md --extra-source=docs/icon.png --extra-source=ui/prefs.ui --extra-source=ui/prefs-gtk4.ui --extra-source=lib
 check:
-	if [[ ! -f "$(UUID).shell-extension.zip" ]]; then \
+	@if [[ ! -f "$(UUID).shell-extension.zip" ]]; then \
 	  echo -e "WARNING! Extension zip couldn't be found"; exit 1; \
 	elif [[ "$$(stat -c %s $(UUID).shell-extension.zip)" -gt 4096000 ]]; then \
 	  echo -e "\nWARNING! The extension is too big to be uploaded to the extensions website, keep it smaller than 4096 KB"; exit 1; \
@@ -18,7 +18,7 @@ check:
 	  echo -e "\nWARNING! Debug mode is enabled, a release shouldn't be published"; exit 1; \
 	fi
 release:
-	if [[ "$(VERSION)" != "" ]]; then \
+	@if [[ "$(VERSION)" != "" ]]; then \
 	  sed -i "s|  \"version\":.*|  \"version\": $(VERSION),|g" metadata.json; \
 	fi
 	#Call other targets required to make a release

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ compress:
 $(PNG_FILES):
 	optipng "$(COMPRESSLEVEL)" -strip all "$@"
 install:
+	@if [[ ! -f "$(UUID).shell-extension.zip" ]]; then \
+	  $(MAKE) build; \
+	fi
 	gnome-extensions install "$(UUID).shell-extension.zip" --force
 uninstall:
 	gnome-extensions uninstall "$(UUID)"

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,7 @@ release:
 	fi
 	#Call other targets required to make a release
 	$(MAKE) gtk4
-	$(MAKE) translations
-	$(MAKE) prune
-	$(MAKE) compress
+	$(MAKE) translations prune compress
 	$(MAKE) build
 	$(MAKE) check
 translations:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 SHELL=bash
 UUID=AlphabeticalAppGrid@stuarthayhurst
 
-PNG_FILES="docs/icon.png"
 COMPRESSLEVEL="-o7"
+PNG_FILES=$(wildcard ./docs/*.png)
 
-.PHONY: build package check release translations gtk4 prune compress install uninstall clean
+.PHONY: build package check release translations gtk4 prune compress install uninstall clean $(PNG_FILES)
 
 build:
 	glib-compile-schemas schemas
@@ -37,8 +37,10 @@ gtk4:
 	gtk4-builder-tool simplify --3to4 ui/prefs.ui > ui/prefs-gtk4.ui
 prune:
 	./scripts/clean-svgs.py
-compress: $(PNG_FILES)
-	optipng "$(COMPRESSLEVEL)" -strip all $(PNG_FILES)
+compress:
+	$(MAKE) $(PNG_FILES)
+$(PNG_FILES):
+	optipng "$(COMPRESSLEVEL)" -strip all "$@"
 install:
 	gnome-extensions install "$(UUID).shell-extension.zip" --force
 uninstall:


### PR DESCRIPTION
## Pull request summary:

Ideas to streamline the build process.

## Build system related changes:

Stops `make` from echoing the entire code of the `if` statements, making it easier to read the output and therefore easier to spot errors. This does not stop `make` from echoing the actual errors!

## Todo:

- I was unsure whether to touch the compression of the `png` files, since this would involve more drastic changes to the `Makefile`. I believe they would only be under the hood though, leaving day-to-day usage of the `make` command the same.
- Also, do you want to have certain targets to be linked? This would also help when debugging/testing new things that require frequent rebuilding. My suggestion would be to always run `make build` before `make install`, so that you don't forget to actually incorporate any changes you made before testing code changes that you just made. What do you think?