### PR TITLE
Update German and French translations

### DIFF
--- a/extension/credits.json
+++ b/extension/credits.json
@@ -3,18 +3,22 @@
     {
       "name": "Stuart Hayhurst",
       "contact": "stuart.a.hayhurst@gmail.com"
+    },
+    {
+      "name": "Philipp Kiemle",
+      "contact": "philipp.kiemle@gmail.com"
     }
   ],
   "translators": [
     {
       "name": "Philipp Kiemle",
       "contact": "philipp.kiemle@gmail.com",
-      "year": "2021"
+      "year": "2021-2022"
     },
     {
       "name": "Heimen Stoffels",
       "contact": "vistausss@fastmail.com",
-      "year": "2021"
+      "year": "2021-2022"
     },
     {
       "name": "Óscar Fernández Díaz",

--- a/extension/po/de.po
+++ b/extension/po/de.po
@@ -1,14 +1,14 @@
 # German translation for the Alphabetical App Grid GNOME Shell Extension.
 # Copyright (C) 2022 Stuart Hayhurst
 # This file is distributed under the same license as the alphabetical-grid-extension package.
-# Philipp Kiemle <philipp.kiemle@gmail.com>, 2021.
+# Philipp Kiemle <philipp.kiemle@gmail.com>, 2021-2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: alphabetical-grid-extension\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-03-23 20:15+0000\n"
-"PO-Revision-Date: 2021-10-09 13:31+0200\n"
+"PO-Revision-Date: 2022-03-25 08:30+0100\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -16,11 +16,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Lokalize 20.12.3\n"
+"X-Generator: Poedit 3.0\n"
 
 #: prefs.js:173 prefs.js:203
 msgid "Settings"
-msgstr ""
+msgstr "Einstellungen"
 
 #: prefs.js:179 prefs.js:204
 msgid "About"
@@ -28,7 +28,7 @@ msgstr "Info"
 
 #: prefs.js:185 prefs.js:205
 msgid "Credits"
-msgstr ""
+msgstr "Danksagungen"
 
 #: ui/about.ui:35 ui/credits.ui:35
 msgid "Alphabetical App Grid"
@@ -40,33 +40,37 @@ msgstr "Stellt die alphabetische Sortierung des Anwendungsrasters wieder her"
 
 #: ui/about.ui:77
 msgid ""
-"<a href=\"https://github.com/stuarthayhurst/alphabetical-grid-"
-"extension\">Contribute on GitHub</a>"
+"<a href=\"https://github.com/stuarthayhurst/alphabetical-grid-extension"
+"\">Contribute on GitHub</a>"
 msgstr ""
-"<a href=\"https://github.com/stuarthayhurst/alphabetical-grid-"
-"extension\">Mitwirken auf GitHub</a>"
+"<a href=\"https://github.com/stuarthayhurst/alphabetical-grid-extension"
+"\">Mitwirken auf GitHub</a>"
 
 #: ui/about.ui:110
 msgid "This program comes with absolutely no warranty."
-msgstr ""
+msgstr "Diese Anwendung wird ohne jegliche Garantie zur Verfügung gestellt."
 
 #: ui/about.ui:122
 msgid ""
 "See the <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GNU General "
 "Public Licence, version 3 or later</a> for details."
 msgstr ""
+"Lesen Sie die <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GNU "
+"General Public Licence, Version 3 oder neuer</a> für Details."
 
 #: ui/credits.ui:65
 msgid "Extension developers:"
-msgstr ""
+msgstr "Erweiterungs-Entwickler:"
 
 #: ui/credits.ui:78
 msgid "Translators:"
-msgstr ""
+msgstr "Übersetzer:"
 
 #: ui/credits.ui:114
 msgid "Thanks to everyone who helped make and translate this extension :)"
 msgstr ""
+"Vielen Dank an alle, die beim Erstellen und Übersetzen der Erweiterung "
+"geholfen haben :)"
 
 #. When this is selected, folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
@@ -91,7 +95,7 @@ msgid ""
 "<a href=\"https://paypal.me/stuartahayhurst\">Consider donating</a> :)"
 msgstr ""
 "Ist das nützlich?\n"
-"<a href=\"https://paypal.me/stuartahayhurst\">Eine Spende wäre nett</a> :)"
+"<a href=\"https://paypal.me/stuartahayhurst\">Eine Spende wäre nett</a> :)"
 
 #: ui/prefs.ui:93
 msgid "General settings"

--- a/extension/po/fr.po
+++ b/extension/po/fr.po
@@ -1,7 +1,7 @@
 # French translation for the Alphabetical App Grid GNOME Shell Extension.
 # Copyright (C) 2022 Stuart Hayhurst
 # This file is distributed under the same license as the alphabetical-grid-extension package.
-# Philipp Kiemle <philipp.kiemle@gmail.com>, 2021.
+# Philipp Kiemle <philipp.kiemle@gmail.com>, 2021-2022.
 #
 msgid ""
 msgstr ""
@@ -19,7 +19,7 @@ msgstr ""
 
 #: prefs.js:173 prefs.js:203
 msgid "Settings"
-msgstr ""
+msgstr "Réglages"
 
 #: prefs.js:179 prefs.js:204
 msgid "About"
@@ -47,25 +47,25 @@ msgstr ""
 
 #: ui/about.ui:110
 msgid "This program comes with absolutely no warranty."
-msgstr ""
+msgstr "Ce programme est livré sans aucune garantie."
 
 #: ui/about.ui:122
 msgid ""
 "See the <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GNU General "
 "Public Licence, version 3 or later</a> for details."
-msgstr ""
+msgstr "Consultez la <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GNU General Public Licence, version 3 ou ultérieure</a> pour plus de détails."
 
 #: ui/credits.ui:65
 msgid "Extension developers:"
-msgstr ""
+msgstr "Développeurs de l’extension:"
 
 #: ui/credits.ui:78
 msgid "Translators:"
-msgstr ""
+msgstr "Traducteurs:"
 
 #: ui/credits.ui:114
 msgid "Thanks to everyone who helped make and translate this extension :)"
-msgstr ""
+msgstr "Merci à tous ceux qui ont aidé à créer et à traduire cette extension :)"
 
 #. When this is selected, folders will appear in alphabetical order, mixed with applications.
 #: ui/prefs-gtk4.ui:11 ui/prefs.ui:14
@@ -90,7 +90,7 @@ msgid ""
 "<a href=\"https://paypal.me/stuartahayhurst\">Consider donating</a> :)"
 msgstr ""
 "Vous avez trouvé cela utile ?\n"
-"<a href=\"https://paypal.me/stuartahayhurst\">Pensez à faire un don</a> :)"
+"<a href=\"https://paypal.me/stuartahayhurst\">Pensez à faire un don</a> :)"
 
 #: ui/prefs.ui:93
 msgid "General settings"


### PR DESCRIPTION
This updates the translations to include the new strings as mentioned in #55.
As French is not my mother tongue and I am not really involved with the French translation team for GNOME, I left some strings untranslated - I am unsure what the "official" translation of those strings is.
I exchanged some whitespace characters with "no-break space" characters (Unicode U+00A0) in front of ":)" or similar, to be consistent with other GNOME translations. Shouldn't affect anything, since the strings are quite short and probably won't wrap to a new line, but hey - :sparkle: consistency :sparkle: xD

I also updated the credits file to include all new translation contributions and added myself as a developer. Thanks :)