### PR TITLE
README: installation tutorial improved, corrected unzip target

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 ## Install the extension from releases:
   - Extract the zip to `~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid@stuarthayhurst/`
   - Reload GNOME: <kbd>ALT</kbd>+<kbd>F2</kbd>, <kbd>r</kbd>, <kbd>ENTER</kbd>
-  - Enable the extension:  
-    `gnome-extensions enable AlphabeticalAppGrid@stuarthayhurst`
+  - Enable the extension: `gnome-extensions enable AlphabeticalAppGrid@stuarthayhurst`
 
 ## Install the extension from source:
   - Make sure the install dependencies are installed

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 ![Extension](docs/icon.png)
 
 ## Install the extension from releases:
-  - Extract the zip to `~/.local/share/gnome-shell-extensions/AlphabeticalAppGrid@stuarthayhurst/`
-  - Reload GNOME
-  - Enable the extension
+  - Extract the zip to `~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid@stuarthayhurst/`
+  - Reload GNOME: <kbd>ALT</kbd>+<kbd>F2</kbd>, <kbd>r</kbd>, <kbd>ENTER</kbd>
+  - Enable the extension:  
+    `gnome-extensions enable AlphabeticalAppGrid@stuarthayhurst`
 
 ## Install the extension from source:
   - Make sure the install dependencies are installed


### PR DESCRIPTION
## Pull request summary
- Fixes the unzip-target directory listed in README: Changed `gnome-shell-extensions` to `gnome-shell/extensions`.
- Adds some detail to the [install-from-release](https://github.com/stuarthayhurst/alphabetical-grid-extension#install-the-extension-from-releases) tutorial.