### PR TITLE
Add GNOME 50 support to metadata

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -11,7 +11,7 @@
     "paypal": "stuartahayhurst"
   },
   "shell-version": [
-    "45", "46", "47", "48", "49"
+    "45", "46", "47", "48", "49", "50"
   ],
   "version": 43
 }


### PR DESCRIPTION
Tested on what will soon be 50.beta and there don't seem to be any compatibility issues. This is required by Edubuntu, and thus indirectly required for Ubuntu 26.04.
